### PR TITLE
Fix ten digits seed generation

### DIFF
--- a/TR2Randomizer/MainWindow.xaml.cs
+++ b/TR2Randomizer/MainWindow.xaml.cs
@@ -119,7 +119,7 @@ namespace TR2Randomizer
 
         private int GenerateSeed()
         {
-            const int max = int.MaxValue;
+            const int max = 1000000000;
             return _rng.Next(0, max);
         }
 

--- a/TR2Randomizer/MainWindow.xaml.cs
+++ b/TR2Randomizer/MainWindow.xaml.cs
@@ -117,28 +117,30 @@ namespace TR2Randomizer
             }
         }
 
+        private int GenerateSeed()
+        {
+            const int max = int.MaxValue;
+            return _rng.Next(0, max);
+        }
+
         private void RandomizeEnemiesSeed()
         {
-            int seed = _rng.Next(0, int.MaxValue);
-            EnemiesSeedEntry.Text = seed.ToString();
+            EnemiesSeedEntry.Text = GenerateSeed().ToString();
         }
 
         private void RandomizeItemsSeed()
         {
-            int seed = _rng.Next(0, int.MaxValue);
-            ItemsSeedEntry.Text = seed.ToString();
+            ItemsSeedEntry.Text = GenerateSeed().ToString();
         }
 
         private void RandomizeSecretsSeed()
         {
-            int seed = _rng.Next(0, int.MaxValue);
-            SecretsSeedEntry.Text = seed.ToString();
+            SecretsSeedEntry.Text = GenerateSeed().ToString();
         }
 
         private void RandomizeTexturesSeed()
         {
-            int seed = _rng.Next(0, int.MaxValue);
-            TextureSeedEntry.Text = seed.ToString();
+            TextureSeedEntry.Text = GenerateSeed().ToString();
         }
 
         private void RandomizeItems_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Made the max randomized seed value 999,999,999 to stay consistent with the UI which currently only allows 9 digits. Loses out on a few ints between 1,000,000,000 and int.MaxValue but I don't think it's a serious issue.