### PR TITLE
Set default intensity for pickups

### DIFF
--- a/TR2Randomizer/Randomizers/ItemRandomizer.cs
+++ b/TR2Randomizer/Randomizers/ItemRandomizer.cs
@@ -68,6 +68,8 @@ namespace TR2Randomizer.Randomizers
                         _levelInstance.Entities[i].X = GlobalizedRandomLocation.X;
                         _levelInstance.Entities[i].Y = GlobalizedRandomLocation.Y;
                         _levelInstance.Entities[i].Z = GlobalizedRandomLocation.Z;
+                        _levelInstance.Entities[i].Intensity1 = -1;
+                        _levelInstance.Entities[i].Intensity2 = -1;
                     }
                 }
             }


### PR DESCRIPTION
Resolves #70.

This makes all pickups have the "regular" lighting. In the future, it may be desired for specific items in certain places to be darker. However, for the current situation, I think this solution just makes the most sense.