### PR TITLE
Move item location near Wreck key to key

### DIFF
--- a/TR2Randomizer/item_locations.json
+++ b/TR2Randomizer/item_locations.json
@@ -50165,9 +50165,9 @@
       "IsItem": true
     },
     {
-      "X": 50797,
-      "Z": 41420,
-      "Y": 4673,
+      "X": 50688,
+      "Z": 41472,
+      "Y": 4864,
       "Room": 41,
       "RequiresGlitch": false,
       "Difficulty": 0,


### PR DESCRIPTION
Resolves #94. Instead of removing it completely, I just put it where it looked like it was supposed to be (on the key).

![image](https://user-images.githubusercontent.com/9002850/99481536-55cf1f00-2928-11eb-880c-282ce31cae02.png)
