### PR TITLE
Fix unarmed softlocks

### DIFF
--- a/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
@@ -275,7 +275,7 @@ namespace TR2RandomizerCore.Randomizers
             {TR2Entities.Shotgun_S_P, 8},
             {TR2Entities.Automags_S_P, 4},
             {TR2Entities.Uzi_S_P, 4},
-            {TR2Entities.Harpoon_S_P, 10},
+            {TR2Entities.Harpoon_S_P, 24},
             {TR2Entities.M16_S_P, 2},
             {TR2Entities.GrenadeLauncher_S_P, 4},
         };

--- a/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
@@ -289,6 +289,14 @@ namespace TR2RandomizerCore.Randomizers
                 ReplacementWeapons.Add(TR2Entities.Pistols_S_P);
 
                 TR2Entities Weap = ReplacementWeapons[_generator.Next(0, ReplacementWeapons.Count)];
+                if (_scriptedLevelInstance.Is(LevelNames.CHICKEN))
+                {
+                    // Grenade Launcher and Harpoon cannot trigger the bells in Ice Palace
+                    while (Weap.Equals(TR2Entities.GrenadeLauncher_S_P) || Weap.Equals(TR2Entities.Harpoon_S_P))
+                    {
+                        Weap = ReplacementWeapons[_generator.Next(0, ReplacementWeapons.Count)];
+                    }
+                }
 
                 TR2Entity unarmedLevelWeapons = _levelInstance.Entities[_unarmedLevelPistolIndex];
 

--- a/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
@@ -256,7 +256,7 @@ namespace TR2RandomizerCore.Randomizers
                 // would be. This is to preserve item indices as the pistols have index 4 - to remove them completely
                 // would mean anything that points to higher item indices (triggers etc) would need to change. The clips
                 // can be safely randomized - it's just the index that needs to remain the same.
-                if (_scriptedLevelInstance.Is("RIG"))
+                if (_scriptedLevelInstance.Is(LevelNames.RIG))
                 {
                     TR2Entity cargoEntity = existingInjections.FirstOrDefault();
                     entities.RemoveAll(e => existingInjections.Contains(e) && e != cargoEntity);
@@ -304,6 +304,8 @@ namespace TR2RandomizerCore.Randomizers
                 if (_startingAmmoToGive.ContainsKey(Weap))
                 {
                     ammoToGive = _startingAmmoToGive[Weap];
+                    if (_scriptedLevelInstance.Is(LevelNames.LAIR))
+                        ammoToGive *= 6;
                 }
 
                 //#68 - Provide some additional ammo for a weapon if not pistols

--- a/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
@@ -270,6 +270,16 @@ namespace TR2RandomizerCore.Randomizers
             }            
         }
 
+        private readonly Dictionary<TR2Entities, uint> _startingAmmoToGive = new Dictionary<TR2Entities, uint>()
+        {
+            {TR2Entities.Shotgun_S_P, 8},
+            {TR2Entities.Automags_S_P, 4},
+            {TR2Entities.Uzi_S_P, 4},
+            {TR2Entities.Harpoon_S_P, 10},
+            {TR2Entities.M16_S_P, 2},
+            {TR2Entities.GrenadeLauncher_S_P, 4},
+        };
+
         private void RandomizeORPistol()
         {
             //Is there something in the unarmed level pistol location?
@@ -282,27 +292,32 @@ namespace TR2RandomizerCore.Randomizers
 
                 TR2Entity unarmedLevelWeapons = _levelInstance.Entities[_unarmedLevelPistolIndex];
 
+                uint ammoToGive = 0;
+                if (_startingAmmoToGive.ContainsKey(Weap))
+                {
+                    ammoToGive = _startingAmmoToGive[Weap];
+                }
+
                 //#68 - Provide some additional ammo for a weapon if not pistols
                 switch (Weap)
                 {
                     case TR2Entities.Shotgun_S_P:
-                        AddORAmmo(TR2Entities.ShotgunAmmo_S_P, 8, unarmedLevelWeapons);
+                        AddORAmmo(TR2Entities.ShotgunAmmo_S_P, ammoToGive, unarmedLevelWeapons);
                         break;
                     case TR2Entities.Automags_S_P:
-                        AddORAmmo(TR2Entities.AutoAmmo_S_P, 4, unarmedLevelWeapons);
+                        AddORAmmo(TR2Entities.AutoAmmo_S_P, ammoToGive, unarmedLevelWeapons);
                         break;
                     case TR2Entities.Uzi_S_P:
-                        AddORAmmo(TR2Entities.UziAmmo_S_P, 4, unarmedLevelWeapons);
+                        AddORAmmo(TR2Entities.UziAmmo_S_P, ammoToGive, unarmedLevelWeapons);
                         break;
                     case TR2Entities.Harpoon_S_P:
-                        AddORAmmo(TR2Entities.HarpoonAmmo_S_P, 10, unarmedLevelWeapons);
+                        AddORAmmo(TR2Entities.HarpoonAmmo_S_P, ammoToGive, unarmedLevelWeapons);
                         break;
                     case TR2Entities.M16_S_P:
-                        AddORAmmo(TR2Entities.M16Ammo_S_P, 2, unarmedLevelWeapons);
+                        AddORAmmo(TR2Entities.M16Ammo_S_P, ammoToGive, unarmedLevelWeapons);
                         break;
                     case TR2Entities.GrenadeLauncher_S_P:
-                        //AddORAmmo(TR2Entities.GrenadeLauncher_S_P, 4, unarmedLevelWeapons);
-                        AddORAmmo(TR2Entities.Grenades_S_P, 4, unarmedLevelWeapons);
+                        AddORAmmo(TR2Entities.Grenades_S_P, ammoToGive, unarmedLevelWeapons);
                         break;
                     default:
                         break;


### PR DESCRIPTION
- Increases unarmed harpoon ammo count (it was less than half the total damage output of other weapons, so I felt it would be nice to be boosted)
- Randomizes Ice Palace unarmed weapon until it is not Grenade Launcher / Harpoon (these cannot trigger bells)
- Adds more ammo (6x) to Dragon's Lair unarmed weapon to almost certainly guarantee completion (Resolves #106)

For now, I made sure the ammo given in Dragon's Lair was quite generous. I tested all guns but I did not test when all enemies are spear jade guardians, which might be borderline impossible in rare situations. However, this gives ammo regardless of if a player is ammoless or not. Furthermore, I assume a difficulty picker in the future will clear up any issues like this, with more precise calculations of ammo given depending on the difficulty. In other words, this seems like such an edge case that I don't think it matters until there is a better idea on how to handle difficulty and its effects on ammo counts.