### PR TITLE
Add Development Mode feature

### DIFF
--- a/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
@@ -16,6 +16,7 @@ namespace TR2RandomizerCore.Randomizers
     public class ItemRandomizer : RandomizerBase
     {
         public bool IncludeKeyItems { get; set; }
+        public bool IsDevelopmentModeOn { get; set; }
 
         // This replaces plane cargo index as TRGE may have randomized the weaponless level(s), but will also have injected pistols
         // into predefined locations. See FindAndCleanUnarmedPistolLocation below.
@@ -97,6 +98,12 @@ namespace TR2RandomizerCore.Randomizers
 
         private void RepositionItems(List<Location> ItemLocs, string lvl)
         {
+            if (IsDevelopmentModeOn)
+            {
+                PlaceAllItems(ItemLocs);
+                return;
+            }
+
             if (ItemLocs.Count > 0)
             {
                 //We are currently looking guns + ammo

--- a/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
@@ -42,7 +42,7 @@ namespace TR2RandomizerCore.Randomizers
                 LoadLevelInstance(lvl);
 
                 FindAndCleanUnarmedPistolLocation(lvl);
-                
+
                 if (lvl.Is(LevelNames.HOME))
                 {
                     InjectHSHWeaponTextures();
@@ -54,7 +54,7 @@ namespace TR2RandomizerCore.Randomizers
 
                 //#44 - Randomize OR pistol type
                 if (lvl.RemovesWeapons) { RandomizeORPistol(); }
-                
+
                 //#47 - Randomize the HSH weapon closet
                 if (lvl.Is(LevelNames.HOME)) { PopulateHSHCloset(); }
 
@@ -63,6 +63,36 @@ namespace TR2RandomizerCore.Randomizers
 
                 SaveMonitor.FireSaveStateChanged(1);
             }
+        }
+
+        // roomNumber is specified if ONLY that room is to be populated
+        private void PlaceAllItems(List<Location> locations, int roomNumber = -1)
+        {
+            List<TR2Entity> ents = _levelInstance.Entities.ToList();
+
+            foreach (Location loc in locations)
+            {
+                Location copy = SpatialConverters.TransformToLevelSpace(loc, _levelInstance.Rooms[loc.Room].Info);
+
+                if (roomNumber == -1 || roomNumber == copy.Room)
+                {
+                    ents.Add(new TR2Entity
+                    {
+                        TypeID = (int)TR2Entities.LargeMed_S_P,
+                        Room = Convert.ToInt16(copy.Room),
+                        X = copy.X,
+                        Y = copy.Y,
+                        Z = copy.Z,
+                        Angle = 0,
+                        Intensity1 = -1,
+                        Intensity2 = -1,
+                        Flags = 0
+                    });
+                }
+            }
+
+            _levelInstance.NumEntities = (uint)ents.Count;
+            _levelInstance.Entities = ents.ToArray();
         }
 
         private void RepositionItems(List<Location> ItemLocs, string lvl)
@@ -269,7 +299,7 @@ namespace TR2RandomizerCore.Randomizers
                 }
                 _levelInstance.NumEntities = (uint)entities.Count;
                 _levelInstance.Entities = entities.ToArray();
-            }            
+            }
         }
 
         private readonly Dictionary<TR2Entities, uint> _startingAmmoToGive = new Dictionary<TR2Entities, uint>()

--- a/TR2RandomizerCore/Randomizers/SecretReplacer.cs
+++ b/TR2RandomizerCore/Randomizers/SecretReplacer.cs
@@ -14,20 +14,18 @@ namespace TR2RandomizerCore.Randomizers
 {
     public class SecretReplacer : RandomizerBase
     {
-        //public bool PlaceAll { get; set; }
-        private bool PlaceAll; //removed from public interface
         public bool AllowHard { get; set; }
+        public bool IsDevelopmentModeOn { get; set; }
         
         public SecretReplacer() : base()
         {
-            PlaceAll = false;
         }
 
         private void RandomizeSecrets(List<Location> LevelLocations, TR23ScriptedLevel lvl)
         {
             if (LevelLocations.Count > 2)
             {
-                if (false && PlaceAll)
+                if (IsDevelopmentModeOn)
                 {
                     PlaceAllSecrets(lvl, LevelLocations);
                     return;

--- a/TR2RandomizerCore/Randomizers/TR2LevelRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/TR2LevelRandomizer.cs
@@ -20,6 +20,7 @@ namespace TR2RandomizerCore.Randomizers
 
         internal bool HardSecrets { get; set; }
         internal bool IncludeKeyItems { get; set; }
+        internal bool DevelopmentMode { get; set; }
 
         internal TR2LevelRandomizer(TRDirectoryIOArgs args)
             : base(args) { }
@@ -39,6 +40,7 @@ namespace TR2RandomizerCore.Randomizers
 
             HardSecrets = config.GetBool("HardSecrets");
             IncludeKeyItems = config.GetBool("IncludeKeyItems");
+            DevelopmentMode = config.GetBool(nameof(DevelopmentMode));
         }
 
         protected override void StoreConfig(Config config)
@@ -55,6 +57,7 @@ namespace TR2RandomizerCore.Randomizers
 
             config["HardSecrets"] = HardSecrets;
             config["IncludeKeyItems"] = IncludeKeyItems;
+            config[nameof(DevelopmentMode)] = DevelopmentMode;
         }
 
         protected override int GetSaveTarget(int numLevels)
@@ -98,6 +101,7 @@ namespace TR2RandomizerCore.Randomizers
                     Levels = levels,
                     BasePath = wipDirectory,
                     SaveMonitor = monitor,
+                    IsDevelopmentModeOn = DevelopmentMode
                 }.Randomize(SecretSeed);
             }
 
@@ -109,7 +113,8 @@ namespace TR2RandomizerCore.Randomizers
                     Levels = levels,
                     BasePath = wipDirectory,
                     SaveMonitor = monitor,
-                    IncludeKeyItems = IncludeKeyItems
+                    IncludeKeyItems = IncludeKeyItems,
+                    IsDevelopmentModeOn = DevelopmentMode
                 }.Randomize(ItemSeed);
             }
 

--- a/TR2RandomizerCore/TR2RandomizerController.cs
+++ b/TR2RandomizerCore/TR2RandomizerController.cs
@@ -215,6 +215,12 @@ namespace TR2RandomizerCore
             get => LevelRandomizer.IncludeKeyItems;
             set => LevelRandomizer.IncludeKeyItems = value;
         }
+
+        public bool DevelopmentMode
+        {
+            get => LevelRandomizer.DevelopmentMode;
+            set => LevelRandomizer.DevelopmentMode = value;
+        }
         #endregion
 
         #region TREditor Passthrough

--- a/TR2RandomizerView/Commands/WindowCommands.cs
+++ b/TR2RandomizerView/Commands/WindowCommands.cs
@@ -19,26 +19,32 @@ namespace TR2RandomizerView.Commands
 
             ImportSettings.InputGestures.Add(new KeyGesture(Key.I, ModifierKeys.Control));
             ExportSettings.InputGestures.Add(new KeyGesture(Key.E, ModifierKeys.Control));
+            DevelopmentMode.InputGestures.Add(new KeyGesture(Key.D, ModifierKeys.Control));
 
             GitHub.InputGestures.Add(new KeyGesture(Key.F1));
         }
 
+        // File
         public static readonly RoutedUICommand Open = new RoutedUICommand();
         public static readonly RoutedUICommand Randomize = new RoutedUICommand();
         public static readonly RoutedUICommand Close = new RoutedUICommand();
         public static readonly RoutedUICommand EmptyRecent = new RoutedUICommand();
         public static readonly RoutedUICommand Exit = new RoutedUICommand();
 
+        // Edit
         public static readonly RoutedUICommand SelectAll = new RoutedUICommand();
         public static readonly RoutedUICommand DeSelectAll = new RoutedUICommand();
         public static readonly RoutedUICommand RandomizeSeeds = new RoutedUICommand();
         public static readonly RoutedUICommand CreateGlobalSeed = new RoutedUICommand();
 
+        // Tools
         public static readonly RoutedUICommand ShowBackup = new RoutedUICommand();
         public static readonly RoutedUICommand Restore = new RoutedUICommand();
         public static readonly RoutedUICommand ImportSettings = new RoutedUICommand();
         public static readonly RoutedUICommand ExportSettings = new RoutedUICommand();
+        public static readonly RoutedUICommand DevelopmentMode = new RoutedUICommand();
 
+        // Help
         public static readonly RoutedUICommand GitHub = new RoutedUICommand();
         public static readonly RoutedUICommand Discord = new RoutedUICommand();
         public static readonly RoutedUICommand CheckForUpdate = new RoutedUICommand();

--- a/TR2RandomizerView/Controls/EditorControl.xaml.cs
+++ b/TR2RandomizerView/Controls/EditorControl.xaml.cs
@@ -288,6 +288,11 @@ namespace TR2RandomizerView.Controls
             }
         }
 
+        public void SetDevelopmentMode(bool flag)
+        {
+            _options.DevelopmentMode = flag;
+        }
+
         public void RandomizeAllSeeds()
         {
             if (_options.RandomizationPossible)

--- a/TR2RandomizerView/Model/ControllerOptions.cs
+++ b/TR2RandomizerView/Model/ControllerOptions.cs
@@ -294,6 +294,17 @@ namespace TR2RandomizerView.Model
             }
         }
 
+        private bool _developmentMode;
+        public bool DevelopmentMode
+        {
+            get => _developmentMode;
+            set
+            {
+                _developmentMode = value;
+                FirePropertyChanged();
+            }
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         protected void FirePropertyChanged([CallerMemberName] string name = null)
@@ -501,6 +512,8 @@ namespace TR2RandomizerView.Model
 
             _controller.RandomizeTextures = RandomizeTextures;
             _controller.TextureSeed = TextureSeed;
+
+            _controller.DevelopmentMode = DevelopmentMode;
         }
 
         public void Unload()

--- a/TR2RandomizerView/Windows/MainWindow.xaml
+++ b/TR2RandomizerView/Windows/MainWindow.xaml
@@ -64,6 +64,10 @@
                         CanExecute="ExportSettingsCommandBinding_CanExecute"
                         Executed="ExportCommandBinding_Executed"/>
 
+        <CommandBinding Command="cmds:WindowCommands.DevelopmentMode"
+                        CanExecute="EditorActiveCommandBinding_CanExecute"
+                        Executed="DevelopmentModeCommandBinding_Executed" />
+
         <CommandBinding Command="cmds:WindowCommands.GitHub"
                         Executed="GitHubCommandBinding_Executed"/>
 
@@ -170,6 +174,13 @@
 
                 <MenuItem Header="Export Settings"
                           Command="cmds:WindowCommands.ExportSettings"/>
+
+                <Separator/>
+
+                <MenuItem Header="Development Mode"
+                          Command="cmds:WindowCommands.DevelopmentMode"
+                          x:Name="DevelopmentModeMenuItem"
+                          ToolTip="Unplayable. Displays all secret and item locations."/>
             </MenuItem>
 
             <MenuItem Header="_Help">

--- a/TR2RandomizerView/Windows/MainWindow.xaml.cs
+++ b/TR2RandomizerView/Windows/MainWindow.xaml.cs
@@ -368,6 +368,12 @@ namespace TR2RandomizerView.Windows
             }
         }
 
+        private void DevelopmentModeCommandBinding_Executed(object sender, ExecutedRoutedEventArgs e)
+        {
+            DevelopmentModeMenuItem.IsChecked = !DevelopmentModeMenuItem.IsChecked;
+            _editorControl.SetDevelopmentMode(DevelopmentModeMenuItem.IsChecked);
+        }
+
         private void EditorFolder_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {
             Process.Start(e.Uri.AbsoluteUri);


### PR DESCRIPTION
Adds a Development Mode toggle button under Tools. When toggled:

- If secrets are randomized, Stone, Jade, and Gold secrets will be created in all their respective locations
- If items are randomized, a Large Med will be created in all item locations

This feature allows quickly scanning all secret and item locations. This helps tremendously for tasks such as fixing broken locations or adding new ones (eg. double checking that none are already there).

P.S. I had no idea what to call this so I just defaulted to Development Mode. Feel free to rename.