### PR TITLE
Add skidoo locations

### DIFF
--- a/TR2RandomizerCore/Randomizers/EnemyRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/EnemyRandomizer.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using TR2RandomizerCore.Helpers;
 using TR2RandomizerCore.Processors;
@@ -417,18 +419,39 @@ namespace TR2RandomizerCore.Randomizers
             // MercSnowMobDriver relies on RedSnowmobile so it will be available in the model list
             if (!level.Is(LevelNames.TIBET))
             {
-                // For now, if MercSnowmobDriver was added, just add a red skidoo where he is.
-                // TODO: Add potential Skidoo zones for each level.
                 TR2Entity mercDriver = level.Data.Entities.ToList().Find(e => e.TypeID == (short)TR2Entities.MercSnowmobDriver);
                 if (mercDriver != null)
                 {
+                    Dictionary<string, List<Location>> allSkidooLocations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(File.ReadAllText(@"Resources\skidoo_locations.json"));
+
+                    short room;
+                    int x, y, z;
+                    if (allSkidooLocations.ContainsKey(level.Name))
+                    {
+                        // we will only spawn one skidoo, so only need one random location
+                        List<Location> levelSkidooLocations = allSkidooLocations[level.Name];
+                        Location randomLocation = levelSkidooLocations[_generator.Next(0, levelSkidooLocations.Count)];
+                        room = (short)randomLocation.Room;
+                        x = randomLocation.X;
+                        y = randomLocation.Y;
+                        z = randomLocation.Z;
+                    }
+                    else
+                    {
+                        // if the level does not have skidoo locations for some reason, just spawn it on the MercSnowMobDriver
+                        room = mercDriver.Room;
+                        x = mercDriver.X;
+                        y = mercDriver.Y;
+                        z = mercDriver.Z;
+                    }
+
                     newEntities.Add(new TR2Entity
                     {
                         TypeID = (short)TR2Entities.RedSnowmobile,
-                        Room = mercDriver.Room,
-                        X = mercDriver.X,
-                        Y = mercDriver.Y,
-                        Z = mercDriver.Z,
+                        Room = room,
+                        X = x,
+                        Y = y,
+                        Z = z,
                         Angle = 16384,
                         Flags = 0,
                         Intensity1 = -1,

--- a/TR2RandomizerCore/Resources/skidoo_locations.json
+++ b/TR2RandomizerCore/Resources/skidoo_locations.json
@@ -1,0 +1,232 @@
+{
+  "WALL.TR2": [
+    {
+      "X": 48681,
+      "Z": 30162,
+      "Y": -1066,
+      "Room": 25,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    },
+    {
+      "X": 28165,
+      "Z": 59891,
+      "Y": 6912,
+      "Room": 51,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "BOAT.TR2": [
+    {
+      "X": 58875,
+      "Z": 22012,
+      "Y": -1027,
+      "Room": 0,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "VENICE.TR2": [
+    {
+      "X": 71810,
+      "Z": 40956,
+      "Y": 4608,
+      "Room": 106,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    },
+    {
+      "X": 58364,
+      "Z": 43532,
+      "Y": 2816,
+      "Room": 32,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    },
+    {
+      "X": 46623,
+      "Z": 35411,
+      "Y": 4608,
+      "Room": 38,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "OPERA.TR2": [
+    {
+      "X": 69146,
+      "Z": 47636,
+      "Y": 5888,
+      "Room": 122,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    },
+    {
+      "X": 72189,
+      "Z": 49670,
+      "Y": -2560,
+      "Room": 19,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "RIG.TR2": [
+    {
+      "X": 48184,
+      "Z": 92664,
+      "Y": -1536,
+      "Room": 4,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "PLATFORM.TR2": [
+    {
+      "X": 21000,
+      "Z": 77278,
+      "Y": -5120,
+      "Room": 54,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "UNWATER.TR2": [
+    {
+      "X": 77597,
+      "Z": 68405,
+      "Y": -5632,
+      "Room": 67,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "KEEL.TR2": [
+    {
+      "X": 67080,
+      "Z": 41463,
+      "Y": 4352,
+      "Room": 45,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "LIVING.TR2": [
+    {
+      "X": 82312,
+      "Z": 78359,
+      "Y": -1770,
+      "Room": 2,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    },
+    {
+      "X": 51624,
+      "Z": 62988,
+      "Y": 68,
+      "Room": 69,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "DECK.TR2": [
+    {
+      "X": 39936,
+      "Z": 59864,
+      "Y": -10850,
+      "Room": 52,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "MONASTRY.TR2": [
+    {
+      "X": 83410,
+      "Z": 22013,
+      "Y": -256,
+      "Room": 23,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "CATACOMB.TR2": [
+    {
+      "X": 28199,
+      "Z": 55795,
+      "Y": 7541,
+      "Room": 107,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    },
+    {
+      "X": 28138,
+      "Z": 40957,
+      "Y": 10752,
+      "Room": 125,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "ICECAVE.TR2": [
+    {
+      "X": 27137,
+      "Z": 59938,
+      "Y": 7186,
+      "Room": 22,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    },
+    {
+      "X": 42343,
+      "Z": 54809,
+      "Y": 3584,
+      "Room": 31,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "EMPRTOMB.TR2": [
+    {
+      "X": 33301,
+      "Z": 48644,
+      "Y": 23930,
+      "Room": 39,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    },
+    {
+      "X": 18972,
+      "Z": 51688,
+      "Y": 12288,
+      "Room": 8,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    },
+    {
+      "X": 13307,
+      "Z": 25600,
+      "Y": 17151,
+      "Room": 150,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    },
+    {
+      "X": 33321,
+      "Z": 41409,
+      "Y": 23925,
+      "Room": 39,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ],
+  "FLOATING.TR2": [
+    {
+      "X": 32000,
+      "Z": 82485,
+      "Y": 3584,
+      "Room": 149,
+      "RequiresGlitch": false,
+      "Difficulty": 0
+    }
+  ]
+}

--- a/TR2RandomizerCore/TR2RandomizerCore.csproj
+++ b/TR2RandomizerCore/TR2RandomizerCore.csproj
@@ -107,6 +107,9 @@
     <None Include="Resources\item_locations.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Resources\skidoo_locations.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Resources\locations.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Changes the spawn of red skidoos. Instead of spawning in the exact same location as black snowmobiles, they will now spawn in one of a few preset locations, specified in _skidoo_locations.json_. I didn't find a lot of good spots in most levels, but the ones that are there are tested and I hope good enough 😄 