### PR TITLE
#153 Skidoo limits

### DIFF
--- a/TR2RandomizerCore/Helpers/TR2CombinedLevel.cs
+++ b/TR2RandomizerCore/Helpers/TR2CombinedLevel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using TR2RandomizerCore.Utilities;
 using TRGE.Core;
 using TRLevelReader.Helpers;
@@ -83,6 +84,25 @@ namespace TR2RandomizerCore.Helpers
                 }
             }
             return levelEntities;
+        }
+
+        public int GetMaximumEntityLimit()
+        {
+            int limit = 256;
+
+            // #153 The game creates a black skidoo for each skidoo driver when the level
+            // is loaded, so there needs to be space in the entity array for these.
+            List<TR2Entity> entities = Data.Entities.ToList();
+            limit -= entities.FindAll(e => e.TypeID == (short)TR2Entities.MercSnowmobDriver).Count;
+
+            // If there is a dragon, we need an extra 7 slots for the front bones, 
+            // back bones etc. This is going by what's seen in Dragon.c
+            if (entities.FindIndex(e => e.TypeID == (short)TR2Entities.MarcoBartoli) != -1)
+            {
+                limit -= 7;
+            }
+
+            return limit;
         }
     }
 }

--- a/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
@@ -78,7 +78,7 @@ namespace TR2RandomizerCore.Randomizers
 
                 //Write back the level file
                 SaveLevelInstance();
-
+                
                 if (!TriggerProgress())
                 {
                     break;
@@ -473,7 +473,7 @@ namespace TR2RandomizerCore.Randomizers
         private void CopyEntity(TR2Entity entity, TR2Entities newType)
         {
             List<TR2Entity> ents = _levelInstance.Data.Entities.ToList();
-            if (ents.Count < 256)
+            if (ents.Count < _levelInstance.GetMaximumEntityLimit())
             {
                 TR2Entity copy = entity.Clone();
                 copy.TypeID = (short)newType;
@@ -508,7 +508,8 @@ namespace TR2RandomizerCore.Randomizers
         {
             List<TR2Entity> ents = _levelInstance.Data.Entities.ToList();
 
-            for (uint i = 0; i < count && ents.Count < 256; i++)
+            int entityLimit = _levelInstance.GetMaximumEntityLimit();
+            for (uint i = 0; i < count && ents.Count < entityLimit; i++)
             {
                 TR2Entity ammo = weapon.Clone();
 


### PR DESCRIPTION
The game creates black skidoos for the drivers when the level is loaded and so it needs space in Entity[] to do this. Checks are now done for this in ItemRandomizer as well as for the dragon - calls to the original CreateItem were scanned and the dragon also needs 7 slots. No other calls to this that fail seem to generate an S_ExitSystem.