### PR TITLE
AI Pathfinding and Environment Randomization

### DIFF
--- a/TR2RandomizerCore/Resources/Environment/BOAT.TR2-Environment.json
+++ b/TR2RandomizerCore/Resources/Environment/BOAT.TR2-Environment.json
@@ -353,6 +353,407 @@
           }
         }
       ]
+    ],
+
+    [
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 34304,
+            "Y": -2048,
+            "Z": 55808,
+            "Room": 77,
+            "Angle": 0
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 35328,
+            "Y": -1792,
+            "Z": 55808,
+            "Room": 77,
+            "Angle": 0
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 35328,
+            "Y": -1792,
+            "Z": 55808,
+            "Room": 77,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 35328,
+            "Y": -1792,
+            "Z": 54784,
+            "Room": 77,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 35328,
+            "Y": -1792,
+            "Z": 53760,
+            "Room": 77,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 35328,
+            "Y": -1792,
+            "Z": 52736,
+            "Room": 77,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 34304,
+            "Y": -1792,
+            "Z": 51712,
+            "Room": 77,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 33280,
+            "Y": -1792,
+            "Z": 51712,
+            "Room": 77,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 32256,
+            "Y": -1792,
+            "Z": 50688,
+            "Room": 77,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 32256,
+            "Y": -1792,
+            "Z": 50688,
+            "Room": 77,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 31232,
+            "Y": -1792,
+            "Z": 50688,
+            "Room": 77,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 30208,
+            "Y": -1792,
+            "Z": 51712,
+            "Room": 77,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 30208,
+            "Y": -1792,
+            "Z": 54784,
+            "Room": 77,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 77.",
+          "EMType": 41,
+          "EntityIndex": 78,
+          "Location": {
+            "X": 31232,
+            "Y": -1792,
+            "Z": 55808,
+            "Room": 77,
+            "Angle": 0
+          }
+        }
+      ]
+    ],
+
+    [
+      [
+        {
+          "Comments": "Potential new position for the switch in room 110.",
+          "EMType": 41,
+          "EntityIndex": 112,
+          "Location": {
+            "X": 33280,
+            "Y": -768,
+            "Z": 58880,
+            "Room": 110,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the switch in room 110.",
+          "EMType": 41,
+          "EntityIndex": 112,
+          "Location": {
+            "X": 35328,
+            "Y": -768,
+            "Z": 58880,
+            "Room": 110,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the switch in room 110.",
+          "EMType": 41,
+          "EntityIndex": 112,
+          "Location": {
+            "X": 35328,
+            "Y": -768,
+            "Z": 57856,
+            "Room": 110,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the switch in room 110.",
+          "EMType": 41,
+          "EntityIndex": 112,
+          "Location": {
+            "X": 35328,
+            "Y": -768,
+            "Z": 57856,
+            "Room": 110,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the switch in room 110.",
+          "EMType": 41,
+          "EntityIndex": 112,
+          "Location": {
+            "X": 34304,
+            "Y": -512,
+            "Z": 57856,
+            "Room": 110,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the switch in room 110.",
+          "EMType": 41,
+          "EntityIndex": 112,
+          "Location": {
+            "X": 33280,
+            "Y": -512,
+            "Z": 57856,
+            "Room": 110,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the switch in room 110.",
+          "EMType": 41,
+          "EntityIndex": 112,
+          "Location": {
+            "X": 34304,
+            "Y": -2304,
+            "Z": 57856,
+            "Room": 82,
+            "Angle": -32768
+          }
+        }
+      ]
+    ],
+
+    [
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 81.",
+          "EMType": 41,
+          "EntityIndex": 88,
+          "Location": {
+            "X": 23040,
+            "Y": -768,
+            "Z": 65024,
+            "Room": 81,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 81.",
+          "EMType": 41,
+          "EntityIndex": 88,
+          "Location": {
+            "X": 23040,
+            "Y": -768,
+            "Z": 65024,
+            "Room": 81,
+            "Angle": 0
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 81.",
+          "EMType": 41,
+          "EntityIndex": 88,
+          "Location": {
+            "X": 24064,
+            "Y": -768,
+            "Z": 65024,
+            "Room": 81,
+            "Angle": 0
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 81.",
+          "EMType": 41,
+          "EntityIndex": 88,
+          "Location": {
+            "X": 23040,
+            "Y": -512,
+            "Z": 61952,
+            "Room": 81,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 81.",
+          "EMType": 41,
+          "EntityIndex": 88,
+          "Location": {
+            "X": 23040,
+            "Y": -256,
+            "Z": 60928,
+            "Room": 81,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 81.",
+          "EMType": 41,
+          "EntityIndex": 88,
+          "Location": {
+            "X": 23040,
+            "Y": 0,
+            "Z": 59904,
+            "Room": 81,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the keyhole in room 81.",
+          "EMType": 41,
+          "EntityIndex": 88,
+          "Location": {
+            "X": 23040,
+            "Y": 0,
+            "Z": 59904,
+            "Room": 81,
+            "Angle": -32768
+          }
+        }
+      ]
     ]
   ],
 

--- a/TR2RandomizerCore/Resources/Environment/CATACOMB.TR2-Environment.json
+++ b/TR2RandomizerCore/Resources/Environment/CATACOMB.TR2-Environment.json
@@ -1,5 +1,15 @@
 {
-  "All": [],
+  "All": [
+    {
+      "Comments": "Fix OG issue of incorrect box overlaps between rooms 74 & 35.",
+      "EMType": 122,
+      "RemoveLinks": {
+        "466": [ 704 ],
+        "467": [ 704 ],
+        "704": [ 466, 467 ]
+      }
+    }
+  ],
 
   "Any": [
     [

--- a/TR2RandomizerCore/Resources/Environment/CATACOMB.TR2-Environment.json
+++ b/TR2RandomizerCore/Resources/Environment/CATACOMB.TR2-Environment.json
@@ -719,7 +719,8 @@
               "Value": 4
             },
             "TrigSetup": {
-              "Value": 15872
+              "Value": 15872,
+              "OneShot": true
             },
             "TrigType": 0,
             "TrigActionList": [

--- a/TR2RandomizerCore/Resources/Environment/DECK.TR2-Environment.json
+++ b/TR2RandomizerCore/Resources/Environment/DECK.TR2-Environment.json
@@ -63,13 +63,13 @@
 
     [
       {
-        "Comments": "A random box beside the stern.",
+        "Comments": "A random box in the first area.",
         "EMType": 1,
         "Location": {
-          "X": 36401,
-          "Y": 1024,
-          "Z": 25023,
-          "Room": 60
+          "X": 43077,
+          "Y": -2048,
+          "Z": 38425,
+          "Room": 20
         },
         "Clicks": -4,
         "SideTexture": 1630,

--- a/TR2RandomizerCore/Resources/Environment/DECK.TR2-Environment.json
+++ b/TR2RandomizerCore/Resources/Environment/DECK.TR2-Environment.json
@@ -193,6 +193,48 @@
       ],
       [
         {
+          "Comments": "Potential new position for the storage keyhole.",
+          "EMType": 41,
+          "EntityIndex": 42,
+          "Location": {
+            "X": 39424,
+            "Y": 3072,
+            "Z": 18944,
+            "Room": 60,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the storage keyhole.",
+          "EMType": 41,
+          "EntityIndex": 42,
+          "Location": {
+            "X": 40448,
+            "Y": 3072,
+            "Z": 18944,
+            "Room": 70,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the storage keyhole.",
+          "EMType": 41,
+          "EntityIndex": 42,
+          "Location": {
+            "X": 39424,
+            "Y": 3072,
+            "Z": 26112,
+            "Room": 60,
+            "Angle": 0
+          }
+        }
+      ],
+      [
+        {
           "Comments": "Potentially convert the keyhole into a switch. Easy Deck.",
           "EMType": 45,
           "EntityIndex": 42,

--- a/TR2RandomizerCore/Resources/Environment/KEEL.TR2-Environment.json
+++ b/TR2RandomizerCore/Resources/Environment/KEEL.TR2-Environment.json
@@ -45,6 +45,40 @@
           }
         }
       }
+    },
+
+    {
+      "Comments": "Make it possible to return to the piston room from below. The fake ladder here becomes real.",
+      "EMType": 0,
+      "IsNegativeZ": true,
+      "Location": {
+        "X": 56826,
+        "Y": 3840,
+        "Z": 13827,
+        "Room": 30
+      },
+      "TextureMap": {
+        "1720": {
+          "27": {
+            "Rectangles": [ 9 ]
+          }
+        }
+      }
+    },
+
+    {
+      "Comments": "Make a block to be able to climb onto the ladder.",
+      "EMType": 1,
+      "Location": {
+        "X": 56826,
+        "Y": 3840,
+        "Z": 13827,
+        "Room": 30
+      },
+      "Clicks": -6,
+      "SideTexture": 1718,
+      "FloorTexture": 1718,
+      "Flags": 6
     }
   ],
 
@@ -129,44 +163,21 @@
     [
       [
         {
-          "Comments": "Make it possible to return to the piston room from below. The fake ladder here becomes real.",
-          "EMType": 0,
-          "IsNegativeZ": true,
-          "Location": {
-            "X": 56826,
-            "Y": 3840,
-            "Z": 13827,
-            "Room": 30
-          },
-          "TextureMap": {
-            "1720": {
-              "27": {
-                "Rectangles": [ 9 ]
-              }
-            }
-          }
-        },
-
-        {
-          "Comments": "Make a block to be able to climb onto the ladder.",
-          "EMType": 1,
-          "Location": {
-            "X": 56826,
-            "Y": 3840,
-            "Z": 13827,
-            "Room": 30
-          },
-          "Clicks": -6,
-          "SideTexture": 1718,
-          "FloorTexture": 1718,
-          "Flags": 6
+          "Comments": "NOOP - use the All method for returning to the piston room from below.",
+          "EMType": 1000
         }
       ],
       [
         {
-          "Comments": "...or flood the upper rooms instead.",
+          "Comments": "...or flood the upper rooms instead. Drain the bottom first to re-apply textures.",
+          "EMType": 3,
+          "RoomNumbers": [ 30 ],
+          "WaterTextures": [ 1769, 1770, 1730, 1764 ]
+        },
+
+        {
           "EMType": 2,
-          "RoomNumbers": [ 28, 29 ],
+          "RoomNumbers": [ 28, 29, 30 ],
           "WaterTextures": [ 1769, 1770, 1730, 1764 ]
         }
       ],
@@ -176,29 +187,6 @@
           "EMType": 3,
           "RoomNumbers": [ 30 ],
           "WaterTextures": [ 1769, 1770, 1730, 1764 ]
-        },
-
-        {
-          "EMType": 0,
-          "IsNegativeZ": true,
-          "Location": {
-            "X": 56826,
-            "Y": 3840,
-            "Z": 13827,
-            "Room": 30
-          },
-          "TextureMap": {
-            "1720": {
-              "27": {
-                "Rectangles": [ 9 ]
-              }
-            },
-            "1724": {
-              "30": {
-                "Rectangles": [ 26, 27 ]
-              }
-            }
-          }
         },
 
         {

--- a/TR2RandomizerCore/Resources/Environment/OPERA.TR2-Environment.json
+++ b/TR2RandomizerCore/Resources/Environment/OPERA.TR2-Environment.json
@@ -675,6 +675,93 @@
           ]
         }
       ]
+    ],
+
+    [
+      [
+        {
+          "Comments": "Potential new position for the switch in room 46.",
+          "EMType": 41,
+          "EntityIndex": 57,
+          "Location": {
+            "X": 72192,
+            "Y": 7936,
+            "Z": 51712,
+            "Room": 46,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the switch in room 46.",
+          "EMType": 41,
+          "EntityIndex": 57,
+          "Location": {
+            "X": 72192,
+            "Y": 7936,
+            "Z": 51712,
+            "Room": 46,
+            "Angle": 0
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the switch in room 46.",
+          "EMType": 41,
+          "EntityIndex": 57,
+          "Location": {
+            "X": 71168,
+            "Y": 7936,
+            "Z": 51712,
+            "Room": 46,
+            "Angle": 0
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the switch in room 46.",
+          "EMType": 41,
+          "EntityIndex": 57,
+          "Location": {
+            "X": 72192,
+            "Y": 7936,
+            "Z": 49664,
+            "Room": 46,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the switch in room 46.",
+          "EMType": 41,
+          "EntityIndex": 57,
+          "Location": {
+            "X": 72192,
+            "Y": 7936,
+            "Z": 49664,
+            "Room": 46,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the switch in room 46.",
+          "EMType": 41,
+          "EntityIndex": 57,
+          "Location": {
+            "X": 71168,
+            "Y": 7936,
+            "Z": 49664,
+            "Room": 46,
+            "Angle": -32768
+          }
+        }
+      ]
     ]
   ],
 
@@ -790,6 +877,231 @@
               "Z": 48640,
               "Room": 190,
               "Angle": 0
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "Leader": [
+        {
+          "Comments": "Remove the default texture behind the switch from room 144.",
+          "EMType": 21,
+          "TextureMap": {
+            "1839": {
+              "144": {
+                "Rectangles": [ 14 ]
+              }
+            }
+          }
+        }
+      ],
+      "Followers": [
+        [
+          {
+            "Comments": "Potential new position for the switch in room 144.",
+            "EMType": 41,
+            "EntityIndex": 158,
+            "Location": {
+              "X": 71168,
+              "Y": 6656,
+              "Z": 46592,
+              "Room": 144,
+              "Angle": -16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1665": {
+                "144": {
+                  "Rectangles": [ 10 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the switch in room 144.",
+            "EMType": 41,
+            "EntityIndex": 158,
+            "Location": {
+              "X": 71168,
+              "Y": 6656,
+              "Z": 45568,
+              "Room": 144,
+              "Angle": -16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1665": {
+                "144": {
+                  "Rectangles": [ 7 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the switch in room 144.",
+            "EMType": 41,
+            "EntityIndex": 158,
+            "Location": {
+              "X": 71168,
+              "Y": 6656,
+              "Z": 44544,
+              "Room": 144,
+              "Angle": -16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1665": {
+                "144": {
+                  "Rectangles": [ 2 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the switch in room 144.",
+            "EMType": 41,
+            "EntityIndex": 158,
+            "Location": {
+              "X": 71168,
+              "Y": 6656,
+              "Z": 44544,
+              "Room": 144,
+              "Angle": -32768
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1665": {
+                "144": {
+                  "Rectangles": [ 4 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the switch in room 144.",
+            "EMType": 41,
+            "EntityIndex": 158,
+            "Location": {
+              "X": 72192,
+              "Y": 6656,
+              "Z": 44544,
+              "Room": 144,
+              "Angle": -32768
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1665": {
+                "144": {
+                  "Rectangles": [ 20 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the switch in room 144.",
+            "EMType": 41,
+            "EntityIndex": 158,
+            "Location": {
+              "X": 72192,
+              "Y": 6656,
+              "Z": 44544,
+              "Room": 144,
+              "Angle": 16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1665": {
+                "144": {
+                  "Rectangles": [ 27 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the switch in room 144.",
+            "EMType": 41,
+            "EntityIndex": 158,
+            "Location": {
+              "X": 72192,
+              "Y": 6656,
+              "Z": 45568,
+              "Room": 144,
+              "Angle": 16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1665": {
+                "144": {
+                  "Rectangles": [ 29 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the switch in room 144.",
+            "EMType": 41,
+            "EntityIndex": 158,
+            "Location": {
+              "X": 72192,
+              "Y": 6656,
+              "Z": 46592,
+              "Room": 144,
+              "Angle": 16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1665": {
+                "144": {
+                  "Rectangles": [ 31 ]
+                }
+              }
             }
           }
         ]

--- a/TR2RandomizerCore/Resources/Environment/PLATFORM.TR2-Environment.json
+++ b/TR2RandomizerCore/Resources/Environment/PLATFORM.TR2-Environment.json
@@ -90,6 +90,16 @@
       },
 
       {
+        "Comments": "Remove the water sound source for above.",
+        "EMType": 103,
+        "Source": {
+          "X": 36352,
+          "Y": 1792,
+          "Z": 56832
+        }
+      },
+
+      {
         "Comments": "Make a step to get out of room 45.",
         "EMType": 1,
         "Location": {
@@ -138,6 +148,16 @@
         "EMType": 3,
         "RoomNumbers": [ 20, 66, 67, 68, 69, 70 ],
         "WaterTextures": [ 2010, 1972, 1900, 2011 ]
+      },
+
+      {
+        "Comments": "Remove the water sound source for above.",
+        "EMType": 103,
+        "Source": {
+          "X": 58880,
+          "Y": -2816,
+          "Z": 87552
+        }
       },
 
       {

--- a/TR2RandomizerCore/Resources/Environment/RIG.TR2-Environment.json
+++ b/TR2RandomizerCore/Resources/Environment/RIG.TR2-Environment.json
@@ -72,6 +72,115 @@
           "Intensity2": 6400
         }
       }
+    ],
+
+    [
+      {
+        "Comments": "Clear unused triggers in DA.",
+        "EMType": 62,
+        "Rooms": [ 72, 74, 84 ]
+      },
+
+      {
+        "Comments": "Move the end trigger.",
+        "EMType": 67,
+        "BaseLocation": {
+          "X": 38421,
+          "Y": -512,
+          "Z": 26107,
+          "Room": 70
+        },
+        "NewLocation": {
+          "X": 31216,
+          "Y": -2304,
+          "Z": 24128,
+          "Room": 72
+        }
+      },
+
+      {
+        "Comments": "Drain the DA pool.",
+        "EMType": 3,
+        "RoomNumbers": [ 74 ],
+        "WaterTextures": [ 1740, 1670, 1648, 1741 ]
+      },
+
+      {
+        "Comments": "Convert the DA button into a pickup.",
+        "EMType": 45,
+        "EntityIndex": 88,
+        "NewEntityType": 144
+      },
+
+      {
+        "Comments": "Move it to the top of the ladder.",
+        "EMType": 44,
+        "EntityIndex": 88,
+        "TargetLocation": {
+          "X": 32231,
+          "Y": -2304,
+          "Z": 24034,
+          "Room": 72,
+          "Angle": 16384
+        }
+      },
+
+      {
+        "Comments": "Convert the DA lever into a pickup.",
+        "EMType": 45,
+        "EntityIndex": 89,
+        "NewEntityType": 150
+      },
+
+      {
+        "Comments": "Put it on the floor.",
+        "EMType": 44,
+        "EntityIndex": 89,
+        "TargetLocation": {
+          "X": 34285,
+          "Y": 4096,
+          "Z": 27443,
+          "Room": 74,
+          "Angle": 16384
+        }
+      },
+
+      {
+        "Comments": "Convert the DA camera target into a pickup.",
+        "EMType": 45,
+        "EntityIndex": 90,
+        "NewEntityType": 148
+      },
+
+      {
+        "Comments": "Put it elsewhere.",
+        "EMType": 44,
+        "EntityIndex": 90,
+        "TargetLocation": {
+          "X": 36352,
+          "Y": -1024,
+          "Z": 24064,
+          "Room": 70,
+          "Angle": 16384
+        }
+      },
+
+      {
+        "Comments": "Adjust some textures.",
+        "EMType": 21,
+        "TextureMap": {
+          "1645": {
+            "74": {
+              "Rectangles": [ 5, 6 ]
+            }
+          },
+          "1681": {
+            "74": {
+              "Rectangles": [ 3, 25, 35 ]
+            }
+          }
+        }
+      }
     ]
   ],
 

--- a/TR2RandomizerCore/Resources/Environment/SKIDOO.TR2-Environment.json
+++ b/TR2RandomizerCore/Resources/Environment/SKIDOO.TR2-Environment.json
@@ -127,6 +127,124 @@
         "EMType": 2,
         "RoomNumbers": [ 50 ],
         "WaterTextures": [ 1487, 1488, 1307, 1489 ]
+      },
+
+      {
+        "Comments": "Adjust a potential secret.",
+        "EMType": 43,
+        "Types": [ 191 ],
+        "SectorLocations": [
+          {
+            "X": 82431,
+            "Y": 4608,
+            "Z": 56935,
+            "Room": 50
+          }
+        ],
+        "TargetLocation": {
+          "X": 89059,
+          "Y": 5120,
+          "Z": 86049,
+          "Room": 44
+        }
+      }
+    ],
+
+    [
+      {
+        "Comments": "Make a ladder to get out of room 129.",
+        "EMType": 0,
+        "IsNegativeX": true,
+        "Location": {
+          "X": 18870,
+          "Y": 18432,
+          "Z": 30200,
+          "Room": 129
+        },
+        "TextureMap": {
+          "1295": {
+            "129": {
+              "Rectangles": [ 38, 39, 40 ]
+            }
+          }
+        }
+      },
+
+      {
+        "Comments": "And then drain it.",
+        "EMType": 3,
+        "RoomNumbers": [ 129 ],
+        "WaterTextures": [ 1487, 1488, 1307, 1489 ]
+      },
+
+      {
+        "Comments": "Remove the water sound source for above.",
+        "EMType": 103,
+        "Source": {
+          "X": 19968,
+          "Y": 14080,
+          "Z": 28160
+        }
+      },
+
+      {
+        "Comments": "Adjust a potential secret.",
+        "EMType": 43,
+        "Types": [ 190 ],
+        "SectorLocations": [
+          {
+            "X": 24653,
+            "Y": 18393,
+            "Z": 27678,
+            "Room": 129
+          }
+        ]
+      }
+    ],
+
+    [
+      {
+        "Comments": "Flood the end room.",
+        "EMType": 2,
+        "RoomNumbers": [ 146, 147 ],
+        "WaterTextures": [ 1487, 1488, 1307, 1489 ]
+      },
+
+      {
+        "Comments": "Move the end trigger.",
+        "EMType": 67,
+        "BaseLocation": {
+          "X": 11787,
+          "Y": 15616,
+          "Z": 33375,
+          "Room": 146
+        },
+        "NewLocation": {
+          "X": 13770,
+          "Y": 15616,
+          "Z": 37371,
+          "Room": 147
+        }
+      },
+
+      {
+        "Comments": "Adjust a potential secret.",
+        "EMType": 43,
+        "Types": [ 190 ],
+        "SectorLocations": [
+          {
+            "X": 11754,
+            "Y": 15616,
+            "Z": 32232,
+            "Room": 146
+          }
+        ],
+        "TargetLocation": {
+          "X": 12309,
+          "Y": 15616,
+          "Z": 37022,
+          "Room": 147
+        }
       }
     ]
   ],

--- a/TR2RandomizerCore/Resources/Environment/VENICE.TR2-Environment.json
+++ b/TR2RandomizerCore/Resources/Environment/VENICE.TR2-Environment.json
@@ -112,6 +112,329 @@
           }
         }
       }
+    ],
+
+    [
+      {
+        "Comments": "Shift the rectangle in room 101 up to make way for a doorway.",
+        "EMType": 23,
+        "Modifications": [
+          {
+            "RoomNumber": 101,
+            "FaceType": 0,
+            "FaceIndex": 2,
+            "VertexChanges": {
+              "0": {
+                "Y": -1024
+              },
+              "1": {
+                "Y": -1024
+              }
+            }
+          },
+          {
+            "RoomNumber": 22,
+            "FaceType": 0,
+            "FaceIndex": 211,
+            "VertexChanges": {
+              "0": {
+                "Y": 512
+              },
+              "1": {
+                "Y": 512
+              }
+            }
+          },
+          {
+            "RoomNumber": 22,
+            "FaceType": 0,
+            "FaceIndex": 212,
+            "VertexChanges": {
+              "2": {
+                "Y": -512
+              },
+              "3": {
+                "Y": -512
+              }
+            }
+          }
+        ]
+      },
+
+      {
+        "Comments": "Refacing for above so textures aren't squashed.",
+        "EMType": 21,
+        "TextureMap": {
+          "1575": {
+            "101": {
+              "Rectangles": [ 2 ]
+            }
+          },
+          "1612": {
+            "22": {
+              "Rectangles": [ 212 ]
+            }
+          },
+          "1613": {
+            "22": {
+              "Rectangles": [ 211 ]
+            }
+          }
+        }
+      },
+
+      {
+        "Comments": "Make visibility portals between rooms 101 & 121.",
+        "EMType": "81",
+        "Portals": {
+          "101": {
+            "AdjoiningRoom": 121,
+            "Normal": {
+              "X": 1,
+              "Y": 0,
+              "Z": 0
+            },
+            "Vertices": [
+              {
+                "X": 1024,
+                "Y": 2304,
+                "Z": 2048
+              },
+              {
+                "X": 1024,
+                "Y": 2304,
+                "Z": 1024
+              },
+              {
+                "X": 1024,
+                "Y": 1024,
+                "Z": 1024
+              },
+              {
+                "X": 1024,
+                "Y": 1024,
+                "Z": 2048
+              }
+            ]
+          },
+          "121": {
+            "AdjoiningRoom": 101,
+            "Normal": {
+              "X": -1,
+              "Y": 0,
+              "Z": 0
+            },
+            "Vertices": [
+              {
+                "X": 12288,
+                "Y": 1280,
+                "Z": 4096
+              },
+              {
+                "X": 12288,
+                "Y": 1280,
+                "Z": 3072
+              },
+              {
+                "X": 12288,
+                "Y": 2304,
+                "Z": 3072
+              },
+              {
+                "X": 12288,
+                "Y": 2304,
+                "Z": 4096
+              }
+            ]
+          }
+        }
+      },
+
+      {
+        "Comments": "Make visibility portals between rooms 22 & 121.",
+        "EMType": "81",
+        "Portals": {
+          "22": {
+            "AdjoiningRoom": 121,
+            "Normal": {
+              "X": -1,
+              "Y": 0,
+              "Z": 0
+            },
+            "Vertices": [
+              {
+                "X": 13312,
+                "Y": 1024,
+                "Z": 2048
+              },
+              {
+                "X": 13312,
+                "Y": 1024,
+                "Z": 3072
+              },
+              {
+                "X": 13312,
+                "Y": 2048,
+                "Z": 3072
+              },
+              {
+                "X": 13312,
+                "Y": 2048,
+                "Z": 2048
+              }
+            ]
+          },
+          "121": {
+            "AdjoiningRoom": 22,
+            "Normal": {
+              "X": 1,
+              "Y": 0,
+              "Z": 0
+            },
+            "Vertices": [
+              {
+                "X": 1024,
+                "Y": 1024,
+                "Z": 4096
+              },
+              {
+                "X": 1024,
+                "Y": 1024,
+                "Z": 5120
+              },
+              {
+                "X": 1024,
+                "Y": 2048,
+                "Z": 5120
+              },
+              {
+                "X": 1024,
+                "Y": 2048,
+                "Z": 4096
+              }
+            ]
+          }
+        }
+      },
+
+      {
+        "Comments": "Make collisional portals between rooms 101 & 121.",
+        "EMType": 82,
+        "Portals": {
+          "101": {
+            "121": [
+              {
+                "X": 66467,
+                "Y": 2304,
+                "Z": 32272
+              }
+            ]
+          },
+          "121": {
+            "101": [
+              {
+                "X": 66669,
+                "Y": 2304,
+                "Z": 32257
+              }
+            ]
+          }
+        }
+      },
+
+      {
+        "Comments": "Make collisional portals between rooms 22 & 121.",
+        "EMType": 82,
+        "Portals": {
+          "22": {
+            "121": [
+              {
+                "X": 55360,
+                "Y": 2048,
+                "Z": 33280
+              }
+            ]
+          },
+          "121": {
+            "22": [
+              {
+                "X": 55229,
+                "Y": 2048,
+                "Z": 33280
+              }
+            ]
+          }
+        }
+      },
+
+      {
+        "Comments": "Render the skybox in room 22, 101 and 106 to avoid issues when looking into the glass room.",
+        "EMType": 121,
+        "Rooms": [ 22, 101, 106 ],
+        "IsSkyboxVisible": true
+      },
+
+      {
+        "Comments": "Add a breeze.",
+        "EMType": 121,
+        "Rooms": [ 121 ],
+        "IsWindy": true
+      },
+
+      {
+        "Comments": "Remove some rectangles we no longer need.",
+        "EMType": 22,
+        "GeometryMap": {
+          "121": {
+            "Rectangles": [ 118, 12 ]
+          }
+        }
+      },
+
+      {
+        "Comments": "Convert a window into a door.",
+        "EMType": 45,
+        "EntityIndex": 29,
+        "NewEntityType": 109
+      },
+
+      {
+        "Comments": "Change its lighting.",
+        "EMType": 48,
+        "EntityIndex": 29,
+        "Intensity1": 4096,
+        "Intensity2": 4096
+      },
+
+      {
+        "Comments": "Move the door to the first portal.",
+        "EMType": 44,
+        "EntityIndex": 29,
+        "TargetLocation": {
+          "X": 67072,
+          "Y": 2304,
+          "Z": 32256,
+          "Room": 101,
+          "Angle": 16384
+        }
+      },
+
+      {
+        "Comments": "Move the trigger for what's now the door. Only usable from one side.",
+        "EMType": 67,
+        "BaseLocation": {
+          "X": 44543,
+          "Y": -1280,
+          "Z": 41503,
+          "Room": 24
+        },
+        "NewLocation": {
+          "X": 66058,
+          "Y": 2304,
+          "Z": 32257,
+          "Room": 121
+        }
+      }
     ]
   ],
 
@@ -183,6 +506,320 @@
             "Y": 1792,
             "Z": 26112,
             "Room": 99,
+            "Angle": -32768
+          }
+        }
+      ]
+    ],
+
+    [
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 66048,
+            "Y": 0,
+            "Z": 33280,
+            "Room": 1,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 66048,
+            "Y": 0,
+            "Z": 32256,
+            "Room": 1,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 66048,
+            "Y": 0,
+            "Z": 31232,
+            "Room": 1,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 66048,
+            "Y": 0,
+            "Z": 30208,
+            "Room": 1,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 66048,
+            "Y": 0,
+            "Z": 29184,
+            "Room": 1,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 66048,
+            "Y": 0,
+            "Z": 28160,
+            "Room": 1,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 66048,
+            "Y": 0,
+            "Z": 27136,
+            "Room": 1,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 66048,
+            "Y": 0,
+            "Z": 27136,
+            "Room": 1,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 65024,
+            "Y": 0,
+            "Z": 27136,
+            "Room": 1,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 62976,
+            "Y": 0,
+            "Z": 27136,
+            "Room": 1,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 61952,
+            "Y": 0,
+            "Z": 27136,
+            "Room": 1,
+            "Angle": -32768
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 61952,
+            "Y": 0,
+            "Z": 27136,
+            "Room": 1,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 61952,
+            "Y": 0,
+            "Z": 28160,
+            "Room": 1,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 61952,
+            "Y": 0,
+            "Z": 29184,
+            "Room": 1,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 61952,
+            "Y": 0,
+            "Z": 32256,
+            "Room": 1,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 61952,
+            "Y": 0,
+            "Z": 33280,
+            "Room": 1,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 61952,
+            "Y": 0,
+            "Z": 33280,
+            "Room": 1,
+            "Angle": 0
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 61952,
+            "Y": -1024,
+            "Z": 34304,
+            "Room": 1,
+            "Angle": 0
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential new position for the lever in room 1.",
+          "EMType": 41,
+          "EntityIndex": 4,
+          "Location": {
+            "X": 61952,
+            "Y": -1024,
+            "Z": 34304,
+            "Room": 1,
+            "Angle": -16384
+          }
+        }
+      ]
+    ],
+
+    [
+      [
+        {
+          "Comments": "Potential position for the keyhole in room 38.",
+          "EMType": 41,
+          "EntityIndex": 41,
+          "Location": {
+            "X": 49664,
+            "Y": 4608,
+            "Z": 34304,
+            "Room": 38,
+            "Angle": 16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential position for the keyhole in room 38.",
+          "EMType": 41,
+          "EntityIndex": 41,
+          "Location": {
+            "X": 46592,
+            "Y": 4608,
+            "Z": 34304,
+            "Room": 38,
+            "Angle": -16384
+          }
+        }
+      ],
+      [
+        {
+          "Comments": "Potential position for the keyhole in room 38.",
+          "EMType": 41,
+          "EntityIndex": 41,
+          "Location": {
+            "X": 46592,
+            "Y": 4608,
+            "Z": 34304,
+            "Room": 38,
             "Angle": -32768
           }
         }
@@ -319,6 +956,501 @@
               "1606": {
                 "110": {
                   "Rectangles": [ 13 ]
+                }
+              }
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "Leader": [
+        {
+          "Comments": "Remove the lever texture from room 41.",
+          "EMType": 21,
+          "TextureMap": {
+            "1650": {
+              "41": {
+                "Rectangles": [ 17 ]
+              }
+            }
+          }
+        }
+      ],
+      "Followers": [
+        [
+          {
+            "Comments": "Make a block where the lever is by default (automatically moves the lever up).",
+            "EMType": 1,
+            "Location": {
+              "X": 45528,
+              "Y": 4608,
+              "Z": 28175,
+              "Room": 41
+            },
+            "Clicks": -4,
+            "FloorTexture": 1650,
+            "SideTexture": 1650,
+            "Flags": 13
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 16 ]
+                }
+              }
+            }
+          },
+
+          {
+            "Comments": "Remove the old wall texture.",
+            "EMType": 22,
+            "GeometryMap": {
+              "41": {
+                "Rectangles": [ 17 ]
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 45568,
+              "Y": 4608,
+              "Z": 29184,
+              "Room": 41,
+              "Angle": -16384
+            }
+          },
+
+          {
+            "Comments": "Make a block where the lever is now (automatically moves the lever up).",
+            "EMType": 1,
+            "Location": {
+              "X": 45528,
+              "Y": 4608,
+              "Z": 29199,
+              "Room": 41
+            },
+            "Clicks": -4,
+            "FloorTexture": 1650,
+            "SideTexture": 1650,
+            "Flags": 9
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 21 ]
+                }
+              }
+            }
+          },
+
+          {
+            "Comments": "Remove the old wall textures.",
+            "EMType": 22,
+            "GeometryMap": {
+              "41": {
+                "Rectangles": [ 20, 22 ]
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 45568,
+              "Y": 4608,
+              "Z": 29184,
+              "Room": 41,
+              "Angle": 0
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 22 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 46592,
+              "Y": 4608,
+              "Z": 29184,
+              "Room": 41,
+              "Angle": 0
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 44 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 49664,
+              "Y": 4608,
+              "Z": 29184,
+              "Room": 41,
+              "Angle": 0
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 93 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 50688,
+              "Y": 4608,
+              "Z": 29184,
+              "Room": 41,
+              "Angle": 0
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 112 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 50688,
+              "Y": 4608,
+              "Z": 29184,
+              "Room": 41,
+              "Angle": 16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 120 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 50688,
+              "Y": 4608,
+              "Z": 28160,
+              "Room": 41,
+              "Angle": 16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 118 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 50688,
+              "Y": 4608,
+              "Z": 25088,
+              "Room": 41,
+              "Angle": 16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 117 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 50688,
+              "Y": 4608,
+              "Z": 24064,
+              "Room": 41,
+              "Angle": 16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 115 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 50688,
+              "Y": 4608,
+              "Z": 24064,
+              "Room": 41,
+              "Angle": -32768
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 97 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 49664,
+              "Y": 4608,
+              "Z": 24064,
+              "Room": 41,
+              "Angle": -32768
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 78 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 46592,
+              "Y": 4608,
+              "Z": 24064,
+              "Room": 41,
+              "Angle": -32768
+            }
+          },
+
+          {
+            "Comments": "Make a block where the lever is by default (automatically moves the lever up).",
+            "EMType": 1,
+            "Location": {
+              "X": 46603,
+              "Y": 4608,
+              "Z": 23947,
+              "Room": 41
+            },
+            "Clicks": -3,
+            "FloorTexture": 1650,
+            "SideTexture": 1650,
+            "Flags": 14
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 27 ]
+                }
+              }
+            }
+          },
+
+          {
+            "Comments": "Remove the old wall texture.",
+            "EMType": 22,
+            "GeometryMap": {
+              "41": {
+                "Rectangles": [ 26 ]
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 45568,
+              "Y": 4608,
+              "Z": 24064,
+              "Room": 41,
+              "Angle": -32768
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 5 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 45568,
+              "Y": 4608,
+              "Z": 24064,
+              "Room": 41,
+              "Angle": -16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 3 ]
+                }
+              }
+            }
+          }
+        ],
+        [
+          {
+            "Comments": "Potential new position for the lever in room 41.",
+            "EMType": 41,
+            "EntityIndex": 43,
+            "Location": {
+              "X": 45568,
+              "Y": 4608,
+              "Z": 25088,
+              "Room": 41,
+              "Angle": -16384
+            }
+          },
+
+          {
+            "Comments": "Adds a lever texture for the above.",
+            "EMType": 21,
+            "TextureMap": {
+              "1606": {
+                "41": {
+                  "Rectangles": [ 9 ]
                 }
               }
             }

--- a/TR2RandomizerCore/Resources/Strings/G11N/gamestrings_EN.json
+++ b/TR2RandomizerCore/Resources/Strings/G11N/gamestrings_EN.json
@@ -681,7 +681,8 @@
         "Avalanche",
         "Skidoo: The Revenge",
         "Skidoo Mania",
-        "Build a Snowman"
+        "Build a Snowman",
+        "Sanctuary of the Skidoo"
       ],
       "Keys": {
         "0": [

--- a/TR2RandomizerCore/Utilities/EnemyUtilities.cs
+++ b/TR2RandomizerCore/Utilities/EnemyUtilities.cs
@@ -451,7 +451,7 @@ namespace TR2RandomizerCore.Utilities
                 List<FDTriggerEntry> triggers = FDUtilities.GetEntityTriggers(fdControl, entityID);
                 foreach (FDTriggerEntry trigger in triggers)
                 {
-                    trigger.TrigSetup.SetOneShot();
+                    trigger.TrigSetup.OneShot = true;
                 }
 
                 fdControl.WriteToLevel(level);

--- a/TREnvironmentEditor/Model/EMType.cs
+++ b/TREnvironmentEditor/Model/EMType.cs
@@ -49,6 +49,7 @@
 
         // Room types 121+
         ModifyRoom = 121,
+        ModifyOverlaps = 122,
 
         // NOOP/Placeholder
         NOOP = 1000

--- a/TREnvironmentEditor/Model/Types/Entities/BaseMoveTriggerableFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Entities/BaseMoveTriggerableFunction.cs
@@ -67,7 +67,7 @@ namespace TREnvironmentEditor.Model.Types
                     currentTrigger.TrigActionList.Add(newAction);
                     if (currentTriggers[0].TrigSetup.OneShot)
                     {
-                        currentTrigger.TrigSetup.SetOneShot();
+                        currentTrigger.TrigSetup.OneShot = true;
                     }
                 }
                 else

--- a/TREnvironmentEditor/Model/Types/Entities/EMConvertEnemyFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Entities/EMConvertEnemyFunction.cs
@@ -16,16 +16,14 @@ namespace TREnvironmentEditor.Model.Types
         {
             // Find the first instance of an existing enemy of the same type
             // we want to convert to. If none found, no action is taken.
-            List<TR2Entities> waterEnemies = TR2EntityUtilities.WaterCreatures();
-            List<TR2Entities> potentialTypes;
+            List<TR2Entities> potentialTypes = TR2EntityUtilities.GetFullListOfEnemies();
             if (NewEnemyType == EnemyType.Land)
             {
-                potentialTypes = TR2EntityUtilities.GetFullListOfEnemies();
-                potentialTypes.RemoveAll(e => waterEnemies.Contains(e));
+                potentialTypes.RemoveAll(e => TR2EntityUtilities.IsWaterCreature(e));
             }
             else
             {
-                potentialTypes = waterEnemies;
+                potentialTypes.RemoveAll(e => !TR2EntityUtilities.IsWaterCreature(e));
             }
 
             if (Exclusions != null && Exclusions.Count > 0)

--- a/TREnvironmentEditor/Model/Types/Rooms/EMModifyOverlapsFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Rooms/EMModifyOverlapsFunction.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using TRLevelReader.Helpers;
+using TRLevelReader.Model;
+
+namespace TREnvironmentEditor.Model.Types
+{
+    public class EMModifyOverlapsFunction : BaseEMFunction
+    {
+        public Dictionary<ushort, List<ushort>> RemoveLinks { get; set; }
+        public Dictionary<ushort, List<ushort>> AddLinks { get; set; }
+
+        public override void ApplyToLevel(TR2Level level)
+        {
+            if (RemoveLinks != null)
+            {
+                foreach (ushort boxIndex in RemoveLinks.Keys)
+                {
+                    TR2Box box = level.Boxes[boxIndex];
+                    List<ushort> overlaps = TR2BoxUtilities.GetOverlaps(level, box);
+                    overlaps.RemoveAll(o => RemoveLinks[boxIndex].Contains(o));
+                    TR2BoxUtilities.UpdateOverlaps(level, box, overlaps);
+                }
+            }
+
+            if (AddLinks != null)
+            {
+                foreach (ushort boxIndex in AddLinks.Keys)
+                {
+                    TR2Box box = level.Boxes[boxIndex];
+                    List<ushort> overlaps = TR2BoxUtilities.GetOverlaps(level, box);
+                    overlaps.AddRange(AddLinks[boxIndex]);
+                    TR2BoxUtilities.UpdateOverlaps(level, box, overlaps);
+                }
+            }
+        }
+    }
+}

--- a/TREnvironmentEditor/Model/Types/Surfaces/EMFloorFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Surfaces/EMFloorFunction.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using TREnvironmentEditor.Helpers;
 using TRFDControl;
 using TRFDControl.Utilities;
+using TRLevelReader.Helpers;
 using TRLevelReader.Model;
 
 namespace TREnvironmentEditor.Model.Types
@@ -171,42 +172,12 @@ namespace TREnvironmentEditor.Model.Types
             room.RoomData.Rectangles = rectangles.ToArray();
             room.RoomData.NumRectangles = (short)rectangles.Count;
 
-            // Now shift the actual sector info
-            sector.Floor += Clicks;
-
-            if (Math.Abs(Clicks) > 1)
-            {
-                // Every box has a corresponding zone containing the normals from what I understand.
-                // For now, duplicate the zone for the new box.
-                List<TR2Zone> zones = level.Zones.ToList();
-                zones.Add(level.Zones[sector.BoxIndex]);
-                level.Zones = zones.ToArray();
-
-                // Make a new box for the sector. Overlapping still needs investigation. Currently, any 
-                // raised or lowered floors will become safe spots as AI can't link to the new boxes.
-                TR2Box currentBox = level.Boxes[sector.BoxIndex];
-                TR2Box box = new TR2Box
-                {
-                    XMin = (byte)((room.Info.X / SectorSize) + (sectorIndex / room.NumZSectors)),
-                    ZMin = (byte)((room.Info.Z / SectorSize) + (sectorIndex % room.NumZSectors)),
-                    TrueFloor = (short)(sector.Floor * ClickSize),
-                    OverlapIndex = currentBox.OverlapIndex
-                };
-
-                // Only 1 tile
-                box.XMax = (byte)(box.XMin + 1);
-                box.ZMax = (byte)(box.ZMin + 1);
-
-                // Point the sector to the new box, and save it to the level
-                sector.BoxIndex = (ushort)level.NumBoxes;
-                List<TR2Box> boxes = level.Boxes.ToList();
-                boxes.Add(box);
-                level.Boxes = boxes.ToArray();
-                level.NumBoxes++;
-            }
-
             // Account for the added faces
             room.NumDataWords = (uint)(room.RoomData.Serialize().Length / 2);
+
+            // Now shift the actual sector info and adjust the box if necessary
+            sector.Floor += Clicks;
+            AlterSectorBox(level, room, sectorIndex);
 
             // Move any entities that share the same floor sector up or down the relevant number of clicks
             foreach (TR2Entity entity in level.Entities)
@@ -220,6 +191,67 @@ namespace TREnvironmentEditor.Model.Types
                     }
                 }
             }
+        }
+
+        private void AlterSectorBox(TR2Level level, TR2Room room, int sectorIndex)
+        {
+            TRRoomSector sector = room.SectorList[sectorIndex];
+            if (sector.BoxIndex == ushort.MaxValue)
+            {
+                return;
+            }
+
+            if (TR2BoxUtilities.GetSectorCount(level, sector.BoxIndex) == 1)
+            {
+                // The box used by this sector is unique to this sector, so we can
+                // simply change the existing floor height to match the sector.
+                level.Boxes[sector.BoxIndex].TrueFloor = (short)(sector.Floor * ClickSize);
+            }
+            else
+            {
+                // Make a new zone to match the addition of a new box.
+                TR2BoxUtilities.DuplicateZone(level, sector.BoxIndex);
+
+                // Make a new box for the sector and link the overlaps.
+                byte xmin = (byte)((room.Info.X / SectorSize) + (sectorIndex / room.NumZSectors));
+                byte zmin = (byte)((room.Info.Z / SectorSize) + (sectorIndex % room.NumZSectors));
+                TR2Box box = new TR2Box
+                {
+                    XMin = xmin,
+                    ZMin = zmin,
+                    XMax = (byte)(xmin + 1), // Only 1 tile
+                    ZMax = (byte)(zmin + 1),
+                    TrueFloor = (short)(sector.Floor * ClickSize),
+                    OverlapIndex = (short)GenerateOverlaps(level, sector.BoxIndex, (ushort)level.NumBoxes)
+                };
+
+                // Point the sector to the new box, and save it to the level
+                sector.BoxIndex = (ushort)level.NumBoxes;
+                List<TR2Box> boxes = level.Boxes.ToList();
+                boxes.Add(box);
+                level.Boxes = boxes.ToArray();
+                level.NumBoxes++;
+            }
+        }
+
+        private int GenerateOverlaps(TR2Level level, ushort currentBoxIndex, ushort newBoxIndex)
+        {
+            foreach (TR2Box box in level.Boxes)
+            {
+                // Anything that has the current box as an overlap will need
+                // to also have the new box.
+                List<ushort> overlaps = TR2BoxUtilities.GetOverlaps(level, box);
+                if (overlaps.Contains(currentBoxIndex))
+                {
+                    // Add the new index and write it back
+                    overlaps.Add(newBoxIndex);
+                    TR2BoxUtilities.UpdateOverlaps(level, box, overlaps);
+                }
+            }
+
+            // For now just add the current box as a neighbour to the new one and return
+            // the overlap index to be set on the new box.
+            return TR2BoxUtilities.InsertOverlaps(level, new List<ushort> { currentBoxIndex });
         }
 
         public void RemapTextures(Dictionary<ushort, ushort> indexMap)

--- a/TREnvironmentEditor/Model/Types/Triggers/EMRemoveTriggerFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Triggers/EMRemoveTriggerFunction.cs
@@ -10,30 +10,50 @@ namespace TREnvironmentEditor.Model.Types
     public class EMRemoveTriggerFunction : BaseEMFunction
     {
         public List<EMLocation> Locations { get; set; }
+        public List<int> Rooms { get; set; }
 
         public override void ApplyToLevel(TR2Level level)
         {
             FDControl control = new FDControl();
             control.ParseFromLevel(level);
 
-            foreach (EMLocation location in Locations)
+            if (Locations != null)
             {
-                TRRoomSector sector = FDUtilities.GetRoomSector(location.X, location.Y, location.Z, location.Room, level, control);
-                if (sector.FDIndex == 0)
+                foreach (EMLocation location in Locations)
                 {
-                    continue;
+                    TRRoomSector sector = FDUtilities.GetRoomSector(location.X, location.Y, location.Z, location.Room, level, control);
+                    RemoveSectorTriggers(sector, control);
                 }
+            }
 
-                List<FDEntry> entries = control.Entries[sector.FDIndex];
-                entries.RemoveAll(e => e is FDTriggerEntry);
-                if (entries.Count == 0)
+            if (Rooms != null)
+            {
+                foreach (int roomNumber in Rooms)
                 {
-                    // If there isn't anything left, reset the sector to point to the dummy FD
-                    control.RemoveFloorData(sector);
+                    foreach (TRRoomSector sector in level.Rooms[roomNumber].SectorList)
+                    {
+                        RemoveSectorTriggers(sector, control);
+                    }
                 }
             }
 
             control.WriteToLevel(level);
+        }
+
+        private void RemoveSectorTriggers(TRRoomSector sector, FDControl control)
+        {
+            if (sector.FDIndex == 0)
+            {
+                return;
+            }
+
+            List<FDEntry> entries = control.Entries[sector.FDIndex];
+            entries.RemoveAll(e => e is FDTriggerEntry);
+            if (entries.Count == 0)
+            {
+                // If there isn't anything left, reset the sector to point to the dummy FD
+                control.RemoveFloorData(sector);
+            }
         }
     }
 }

--- a/TREnvironmentEditor/Parsing/EMConverter.cs
+++ b/TREnvironmentEditor/Parsing/EMConverter.cs
@@ -120,6 +120,8 @@ namespace TREnvironmentEditor.Parsing
                 // Rooms
                 case EMType.ModifyRoom:
                     return JsonConvert.DeserializeObject<EMModifyRoomFunction>(jo.ToString(), _resolver);
+                case EMType.ModifyOverlaps:
+                    return JsonConvert.DeserializeObject<EMModifyOverlapsFunction>(jo.ToString(), _resolver);
 
                 // NOOP
                 case EMType.NOOP:

--- a/TRFDControl/FDTrigSetup.cs
+++ b/TRFDControl/FDTrigSetup.cs
@@ -24,6 +24,17 @@ namespace TRFDControl
             {
                 return (Value & 0x0100) > 0;
             }
+            set
+            {
+                if (value)
+                {
+                    Value |= 0x0100;
+                }
+                else
+                {
+                    Value ^= 0x0100;
+                }
+            }
         }
 
         public byte Mask
@@ -37,16 +48,6 @@ namespace TRFDControl
                 Value = (ushort)(Value & ~(Value & 0x3E00));
                 Value |= (ushort)(value << 9);
             }
-        }
-
-        public void SetOneShot()
-        {
-            Value |= 0x0100;
-        }
-
-        public void ClearOneShot()
-        {
-            Value ^= 0x0100;
         }
     }
 }

--- a/TRLevelReader/Helpers/TR2BoxUtilities.cs
+++ b/TRLevelReader/Helpers/TR2BoxUtilities.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TRLevelReader.Model;
+using TRLevelReader.Model.TR2.Enums;
+
+namespace TRLevelReader.Helpers
+{
+    public class TR2BoxUtilities
+    {
+        public static readonly ushort BoxNumber = 0x7fff;
+        public static readonly short OverlapIndex = 0x3fff;
+        public static readonly ushort EndBit = 0x8000;
+        public static readonly int Blockable = 0x8000;
+        public static readonly int Blocked = 0x4000;
+
+        public static ushort GetZoneValue(TR2Level level, TR2Zones zone, FlipStatus flip, int boxIndex, Normal normal = Normal.Normal1)
+        {
+            return zone == TR2Zones.Ground ? level.GroundZone[(int)flip][(int)normal][boxIndex] : level.FlyZone[(int)flip][boxIndex];
+        }
+
+        public static TR2Zone GetZone(TR2Level level, int boxIndex)
+        {
+            // This is just a representation of the zoning, we use the manual approach instead
+            return new TR2Zone
+            {
+                GroundZone1Normal = level.GroundZone[(int)FlipStatus.Off][(int)Normal.Normal1][boxIndex],
+                GroundZone2Normal = level.GroundZone[(int)FlipStatus.Off][(int)Normal.Normal2][boxIndex],
+                GroundZone3Normal = level.GroundZone[(int)FlipStatus.Off][(int)Normal.Normal3][boxIndex],
+                GroundZone4Normal = level.GroundZone[(int)FlipStatus.Off][(int)Normal.Normal4][boxIndex],
+
+                GroundZone1Alternate = level.GroundZone[(int)FlipStatus.On][(int)Normal.Normal1][boxIndex],
+                GroundZone2Alternate = level.GroundZone[(int)FlipStatus.On][(int)Normal.Normal2][boxIndex],
+                GroundZone3Alternate = level.GroundZone[(int)FlipStatus.On][(int)Normal.Normal3][boxIndex],
+                GroundZone4Alternate = level.GroundZone[(int)FlipStatus.On][(int)Normal.Normal4][boxIndex],
+
+                FlyZoneNormal = level.FlyZone[(int)FlipStatus.Off][boxIndex],
+                FlyZoneAlternate = level.FlyZone[(int)FlipStatus.On][boxIndex]
+            };
+        }
+
+        public static void DuplicateZone(TR2Level level, int boxIndex)
+        {
+            IEnumerable<int> flipValues = Enum.GetValues(typeof(FlipStatus)).Cast<int>();
+            IEnumerable<int> normValues = Enum.GetValues(typeof(Normal)).Cast<int>();
+
+            foreach (int flip in flipValues)
+            {
+                foreach (int norm in normValues)
+                {
+                    List<ushort> groundValues = level.GroundZone[flip][norm].ToList();
+                    groundValues.Add(groundValues[boxIndex]);
+                    level.GroundZone[flip][norm] = groundValues.ToArray();
+                }
+
+                List<ushort> flyValues = level.FlyZone[flip].ToList();
+                flyValues.Add(flyValues[boxIndex]);
+                level.FlyZone[flip] = flyValues.ToArray();
+            }
+        }
+
+        public static void ReadZones(TR2Level level, BinaryReader reader)
+        {
+            IEnumerable<int> flipValues = Enum.GetValues(typeof(FlipStatus)).Cast<int>();
+            IEnumerable<int> normValues = Enum.GetValues(typeof(Normal)).Cast<int>();
+
+            level.GroundZone = new ushort[flipValues.Count()][][];
+            level.FlyZone = new ushort[flipValues.Count()][];
+
+            foreach (int flip in flipValues)
+            {
+                level.GroundZone[flip] = new ushort[normValues.Count()][];
+                foreach (int norm in normValues)
+                {
+                    level.GroundZone[flip][norm] = new ushort[level.NumBoxes];
+                    for (int box = 0; box < level.NumBoxes; box++)
+                    {
+                        level.GroundZone[flip][norm][box] = reader.ReadUInt16();
+                    }
+                }
+
+                level.FlyZone[flip] = new ushort[level.NumBoxes];
+                for (int box = 0; box < level.NumBoxes; box++)
+                {
+                    level.FlyZone[flip][box] = reader.ReadUInt16();
+                }
+            }
+        }
+
+        public static ushort[] FlattenZones(TR2Level level)
+        {
+            IEnumerable<FlipStatus> flipValues = Enum.GetValues(typeof(FlipStatus)).Cast<FlipStatus>();
+            IEnumerable<Normal> normValues = Enum.GetValues(typeof(Normal)).Cast<Normal>();
+
+            List<ushort> zones = new List<ushort>();
+
+            foreach (FlipStatus flip in flipValues)
+            {
+                foreach (Normal norm in normValues)
+                {
+                    for (int box = 0; box < level.NumBoxes; box++)
+                    {
+                        zones.Add(GetZoneValue(level, TR2Zones.Ground, flip, box, norm));
+                    }
+                }
+
+                for (int box = 0; box < level.NumBoxes; box++)
+                {
+                    zones.Add(GetZoneValue(level, TR2Zones.Fly, flip, box));
+                }
+            }
+
+            return zones.ToArray();
+        }
+
+        public static int GetSectorCount(TR2Level level, int boxIndex)
+        {
+            int count = 0;
+            foreach (TR2Room room in level.Rooms)
+            {
+                foreach (TRRoomSector sector in room.SectorList)
+                {
+                    if (sector.BoxIndex == boxIndex)
+                    {
+                        count++;
+                    }
+                }
+            }
+            return count;
+        }
+
+        public static List<ushort> GetOverlaps(TR2Level level, TR2Box box)
+        {
+            List<ushort> overlaps = new List<ushort>();
+
+            if (box.OverlapIndex != -1)
+            {
+                int index = box.OverlapIndex & OverlapIndex;
+                ushort boxNumber;
+                bool done = false;
+                do
+                {
+                    boxNumber = level.Overlaps[index++];
+                    if ((boxNumber & EndBit) > 0)
+                    {
+                        done = true;
+                        boxNumber &= BoxNumber;
+                    }
+                    overlaps.Add(boxNumber);
+                }
+                while (!done);
+            }
+
+            return overlaps;
+        }
+
+        public static int InsertOverlaps(TR2Level level, List<ushort> overlaps)
+        {
+            // This is inefficient currently as we just append rather than shifting
+            // everything else, so previous entries remain.
+            List<ushort> levelOverlaps = level.Overlaps.ToList();
+            for (int i = 0; i < overlaps.Count; i++)
+            {
+                ushort index = overlaps[i];
+                if (i == overlaps.Count - 1)
+                {
+                    index |= EndBit;
+                }
+                levelOverlaps.Add(index);
+            }
+
+            int newIndex = (int)level.NumOverlaps;
+            level.Overlaps = levelOverlaps.ToArray();
+            level.NumOverlaps = (uint)levelOverlaps.Count;
+
+            return newIndex;
+        }
+
+        public static void UpdateOverlapIndex(TR2Box box, int index)
+        {
+            if ((box.OverlapIndex & Blockable) > 0)
+            {
+                index |= Blockable;
+            }
+            if ((box.OverlapIndex & Blocked) > 0)
+            {
+                index |= Blocked;
+            }
+            box.OverlapIndex = (short)index;
+        }
+
+        public static void UpdateOverlaps(TR2Level level, TR2Box box, List<ushort> overlaps)
+        {
+            int index = InsertOverlaps(level, overlaps);
+            UpdateOverlapIndex(box, index);
+        }
+    }
+}

--- a/TRLevelReader/Model/Base/Enums/FlipStatus.cs
+++ b/TRLevelReader/Model/Base/Enums/FlipStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace TRLevelReader.Model.Base.Enums
+{
+    public enum FlipStatus
+    {
+        Off = 0,
+        On = 1
+    }
+}

--- a/TRLevelReader/Model/TR2/Enums/TR2Zones.cs
+++ b/TRLevelReader/Model/TR2/Enums/TR2Zones.cs
@@ -1,0 +1,22 @@
+﻿namespace TRLevelReader.Model.TR2.Enums
+{
+    public enum TR2Zones
+    {
+        Ground = 0,
+        Fly = 1
+    }
+
+    public enum FlipStatus
+    {
+        Off = 0,
+        On = 1
+    }
+
+    public enum Normal
+    {
+        Normal1 = 0,
+        Normal2 = 1,
+        Normal3 = 2,
+        Normal4 = 3
+    }
+}

--- a/TRLevelReader/Model/TR2/Enums/TR2Zones.cs
+++ b/TRLevelReader/Model/TR2/Enums/TR2Zones.cs
@@ -2,21 +2,9 @@
 {
     public enum TR2Zones
     {
-        Ground = 0,
-        Fly = 1
-    }
-
-    public enum FlipStatus
-    {
-        Off = 0,
-        On = 1
-    }
-
-    public enum Normal
-    {
-        Normal1 = 0,
-        Normal2 = 1,
-        Normal3 = 2,
-        Normal4 = 3
+        Zone1 = 0,
+        Zone2 = 1,
+        Zone3 = 2,
+        Zone4 = 3
     }
 }

--- a/TRLevelReader/Model/TR2/TR2Level.cs
+++ b/TRLevelReader/Model/TR2/TR2Level.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TRLevelReader.Helpers;
 using TRLevelReader.Serialization;
 
 //https://trwiki.earvillage.net/doku.php?id=trsone
@@ -247,7 +248,9 @@ namespace TRLevelReader.Model
         /// <summary>
         /// NumBoxes * 20 bytes (double check this)
         /// </summary>
-        public TR2Zone[] Zones { get; set; }
+        //public TR2Zone[] Zones { get; set; }
+        public ushort[][][] GroundZone { get; set; }
+        public ushort[][] FlyZone { get; set; }
 
         /// <summary>
         /// 4 bytes
@@ -380,7 +383,9 @@ namespace TRLevelReader.Model
                     foreach (TR2Box box in Boxes) { writer.Write(box.Serialize()); }
                     writer.Write(NumOverlaps);
                     foreach (ushort overlap in Overlaps) { writer.Write(overlap); }
-                    foreach (TR2Zone zone in Zones) { writer.Write(zone.Serialize()); }
+                    //See note in TR2LevelReader re zones
+                    //foreach (TR2Zone zone in Zones) { writer.Write(zone.Serialize()); }
+                    foreach (ushort zone in TR2BoxUtilities.FlattenZones(this)) { writer.Write(zone); }
                     writer.Write(NumAnimatedTextures);
                     writer.Write((ushort)AnimatedTextures.Length);
                     foreach (TRAnimatedTexture texture in AnimatedTextures) { writer.Write(texture.Serialize()); }

--- a/TRLevelReader/Model/TR2/TR2Level.cs
+++ b/TRLevelReader/Model/TR2/TR2Level.cs
@@ -248,9 +248,7 @@ namespace TRLevelReader.Model
         /// <summary>
         /// NumBoxes * 20 bytes (double check this)
         /// </summary>
-        //public TR2Zone[] Zones { get; set; }
-        public ushort[][][] GroundZone { get; set; }
-        public ushort[][] FlyZone { get; set; }
+        public TR2ZoneGroup[] Zones { get; set; }
 
         /// <summary>
         /// 4 bytes
@@ -384,8 +382,7 @@ namespace TRLevelReader.Model
                     writer.Write(NumOverlaps);
                     foreach (ushort overlap in Overlaps) { writer.Write(overlap); }
                     //See note in TR2LevelReader re zones
-                    //foreach (TR2Zone zone in Zones) { writer.Write(zone.Serialize()); }
-                    foreach (ushort zone in TR2BoxUtilities.FlattenZones(this)) { writer.Write(zone); }
+                    foreach (ushort zone in TR2BoxUtilities.FlattenZones(Zones)) { writer.Write(zone); }
                     writer.Write(NumAnimatedTextures);
                     writer.Write((ushort)AnimatedTextures.Length);
                     foreach (TRAnimatedTexture texture in AnimatedTextures) { writer.Write(texture.Serialize()); }

--- a/TRLevelReader/Model/TR2/TR2Zone.cs
+++ b/TRLevelReader/Model/TR2/TR2Zone.cs
@@ -2,33 +2,20 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using TRLevelReader.Model.TR2.Enums;
 using TRLevelReader.Serialization;
 
 namespace TRLevelReader.Model
 {
-    public class TR2Zone : ISerializableCompact
+    public class TR2Zone : ISerializableCompact, ICloneable
     {
-        public ushort GroundZone1Normal { get; set; }
+        public Dictionary<TR2Zones, ushort> GroundZones { get; set; }
+        public ushort FlyZone { get; set; }
 
-        public ushort GroundZone2Normal { get; set; }
-
-        public ushort GroundZone3Normal { get; set; }
-
-        public ushort GroundZone4Normal { get; set; }
-
-        public ushort FlyZoneNormal { get; set; }
-
-        public ushort GroundZone1Alternate { get; set; }
-
-        public ushort GroundZone2Alternate { get; set; }
-
-        public ushort GroundZone3Alternate { get; set; }
-
-        public ushort GroundZone4Alternate { get; set; }
-
-        public ushort FlyZoneAlternate { get; set; }
+        public TR2Zone()
+        {
+            GroundZones = new Dictionary<TR2Zones, ushort>();
+        }
 
         public byte[] Serialize()
         {
@@ -36,20 +23,29 @@ namespace TRLevelReader.Model
             {
                 using (BinaryWriter writer = new BinaryWriter(stream))
                 {
-                    writer.Write(GroundZone1Normal);
-                    writer.Write(GroundZone2Normal);
-                    writer.Write(GroundZone3Normal);
-                    writer.Write(GroundZone4Normal);
-                    writer.Write(FlyZoneNormal);
-                    writer.Write(GroundZone1Alternate);
-                    writer.Write(GroundZone2Alternate);
-                    writer.Write(GroundZone3Alternate);
-                    writer.Write(GroundZone4Alternate);
-                    writer.Write(FlyZoneAlternate);
+                    foreach (ushort zone in GroundZones.Values)
+                    {
+                        writer.Write(zone);
+                    }
+                    writer.Write(FlyZone);
                 }
 
                 return stream.ToArray();
             }
+        }
+
+        public TR2Zone Clone()
+        {
+            return new TR2Zone
+            {
+                GroundZones = GroundZones.ToDictionary(e => e.Key, e => e.Value),
+                FlyZone = FlyZone
+            };
+        }
+
+        object ICloneable.Clone()
+        {
+            return Clone();
         }
     }
 }

--- a/TRLevelReader/Model/TR2/TR2ZoneGroup.cs
+++ b/TRLevelReader/Model/TR2/TR2ZoneGroup.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using TRLevelReader.Model.Base.Enums;
+
+namespace TRLevelReader.Model
+{
+    public class TR2ZoneGroup : Dictionary<FlipStatus, TR2Zone>
+    {
+        /// <summary>
+        /// Zone values when flipmap is off.
+        /// </summary>
+        public TR2Zone NormalZone
+        {
+            get => this[FlipStatus.Off];
+            set => this[FlipStatus.Off] = value;
+        }
+        /// <summary>
+        /// Zone values when flipmap is on.
+        /// </summary>
+        public TR2Zone AlternateZone
+        {
+            get => this[FlipStatus.On];
+            set => this[FlipStatus.On] = value;
+        }
+    }
+}

--- a/TRLevelReader/TR2FileReadUtilities.cs
+++ b/TRLevelReader/TR2FileReadUtilities.cs
@@ -321,23 +321,6 @@ namespace TRLevelReader
             };
         }
 
-        public static TR2Zone ReadZone(BinaryReader reader)
-        {
-            return new TR2Zone
-            {
-                GroundZone1Normal = reader.ReadUInt16(),
-                GroundZone2Normal = reader.ReadUInt16(),
-                GroundZone3Normal = reader.ReadUInt16(),
-                GroundZone4Normal = reader.ReadUInt16(),
-                FlyZoneNormal = reader.ReadUInt16(),
-                GroundZone1Alternate = reader.ReadUInt16(),
-                GroundZone2Alternate = reader.ReadUInt16(),
-                GroundZone3Alternate = reader.ReadUInt16(),
-                GroundZone4Alternate = reader.ReadUInt16(),
-                FlyZoneAlternate = reader.ReadUInt16()
-            };
-        }
-
         public static TRAnimatedTexture ReadAnimatedTexture(BinaryReader reader)
         {
             ushort numTextures = reader.ReadUInt16(); // Actually num textures - 1, see https://opentomb.github.io/TRosettaStone3/trosettastone.html#_animated_textures_2

--- a/TRLevelReader/TR2LevelReader.cs
+++ b/TRLevelReader/TR2LevelReader.cs
@@ -300,7 +300,6 @@ namespace TRLevelReader
             //Overlaps & Zones
             level.NumOverlaps = reader.ReadUInt32();
             level.Overlaps = new ushort[level.NumOverlaps];
-            //level.Zones = new TR2Zone[level.NumBoxes];
 
             for (int i = 0; i < level.NumOverlaps; i++)
             {
@@ -309,13 +308,14 @@ namespace TRLevelReader
 
             // Although TRosettaStone references a struct for zones, the data isn't
             // sequential. Instead it's organised by flipmap status, all the groundzone
-            // normals are then together and the flyzones at the end. TR2BoxUtilities
-            // handles the complexity here.
-            TR2BoxUtilities.ReadZones(level, reader);
-            //for (int i = 0; i < level.NumBoxes; i++)
-            //{
-            //    level.Zones[i] = TR2FileReadUtilities.ReadZone(reader);
-            //}
+            // values are then together and the flyzones at the end. TR2BoxUtilities
+            // handles the complexity here, so we just pass the raw ushort values.
+            ushort[] zoneData = new ushort[level.NumBoxes * 10];
+            for (int i = 0; i < zoneData.Length; i++)
+            {
+                zoneData[i] = reader.ReadUInt16();
+            }
+            level.Zones = TR2BoxUtilities.ReadZones(level.NumBoxes, zoneData);
 
             //Animated Textures - the data stores the total number of ushorts to read (NumAnimatedTextures)
             //followed by a ushort to describe the number of actual texture group objects.

--- a/TRLevelReader/TR2LevelReader.cs
+++ b/TRLevelReader/TR2LevelReader.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TRLevelReader.Helpers;
 using TRLevelReader.Model;
 
 namespace TRLevelReader
@@ -299,17 +300,22 @@ namespace TRLevelReader
             //Overlaps & Zones
             level.NumOverlaps = reader.ReadUInt32();
             level.Overlaps = new ushort[level.NumOverlaps];
-            level.Zones = new TR2Zone[level.NumBoxes];
+            //level.Zones = new TR2Zone[level.NumBoxes];
 
             for (int i = 0; i < level.NumOverlaps; i++)
             {
                 level.Overlaps[i] = reader.ReadUInt16();
             }
 
-            for (int i = 0; i < level.NumBoxes; i++)
-            {
-                level.Zones[i] = TR2FileReadUtilities.ReadZone(reader);
-            }
+            // Although TRosettaStone references a struct for zones, the data isn't
+            // sequential. Instead it's organised by flipmap status, all the groundzone
+            // normals are then together and the flyzones at the end. TR2BoxUtilities
+            // handles the complexity here.
+            TR2BoxUtilities.ReadZones(level, reader);
+            //for (int i = 0; i < level.NumBoxes; i++)
+            //{
+            //    level.Zones[i] = TR2FileReadUtilities.ReadZone(reader);
+            //}
 
             //Animated Textures - the data stores the total number of ushorts to read (NumAnimatedTextures)
             //followed by a ushort to describe the number of actual texture group objects.

--- a/TRLevelReaderUnitTests/TR2Level_UnitTests.cs
+++ b/TRLevelReaderUnitTests/TR2Level_UnitTests.cs
@@ -11,6 +11,7 @@ using TRFDControl.FDEntryTypes;
 using TRFDControl.Utilities;
 using System.Linq;
 using TRLevelReader.Helpers;
+using TRLevelReader.Model.Base.Enums;
 
 namespace TRLevelReaderUnitTests
 {
@@ -1211,10 +1212,12 @@ namespace TRLevelReaderUnitTests
 
             // For every box, store the current zone. We use the serialized form
             // for comparison.
-            Dictionary<int, byte[]> boxZones = new Dictionary<int, byte[]>();
+            Dictionary<int, byte[]> flipOffZones = new Dictionary<int, byte[]>();
+            Dictionary<int, byte[]> flipOnZones = new Dictionary<int, byte[]>();
             for (int i = 0; i < lvl.NumBoxes; i++)
             {
-                boxZones[i] = TR2BoxUtilities.GetZone(lvl, i).Serialize();
+                flipOffZones[i] = lvl.Zones[i][FlipStatus.Off].Serialize();
+                flipOnZones[i] = lvl.Zones[i][FlipStatus.On].Serialize();
             }
 
             // Add a new box
@@ -1226,10 +1229,11 @@ namespace TRLevelReaderUnitTests
             // Add a new zone for the box and store its serialized form for comparison
             int newBoxIndex = (int)(lvl.NumBoxes - 1);
             TR2BoxUtilities.DuplicateZone(lvl, 0);
-            boxZones[newBoxIndex] = TR2BoxUtilities.GetZone(lvl, newBoxIndex).Serialize();
+            flipOffZones[newBoxIndex] = lvl.Zones[newBoxIndex][FlipStatus.Off].Serialize();
+            flipOnZones[newBoxIndex] = lvl.Zones[newBoxIndex][FlipStatus.On].Serialize();
 
             // Verify the number of zone ushorts matches what's expected for the box count
-            Assert.AreEqual(TR2BoxUtilities.FlattenZones(lvl).Length, (int)(10 * lvl.NumBoxes));
+            Assert.AreEqual(TR2BoxUtilities.FlattenZones(lvl.Zones).Length, (int)(10 * lvl.NumBoxes));
 
             // Write and re-read the level
             new TR2LevelWriter().WriteLevelToFile(lvl, "TEST.tr2");
@@ -1239,9 +1243,13 @@ namespace TRLevelReaderUnitTests
             // affect any of the others and that the addition itself matches after IO.
             for (int i = 0; i < lvl.NumBoxes; i++)
             {
-                byte[] zones = TR2BoxUtilities.GetZone(lvl, i).Serialize();
-                Assert.IsTrue(boxZones.ContainsKey(i));
-                CollectionAssert.AreEqual(boxZones[i], zones);
+                byte[] flipOff = lvl.Zones[i][FlipStatus.Off].Serialize();
+                Assert.IsTrue(flipOffZones.ContainsKey(i));
+                CollectionAssert.AreEqual(flipOffZones[i], flipOff);
+
+                byte[] flipOn = lvl.Zones[i][FlipStatus.On].Serialize();
+                Assert.IsTrue(flipOnZones.ContainsKey(i));
+                CollectionAssert.AreEqual(flipOnZones[i], flipOn);
             }
         }
 

--- a/TRLevelReaderUnitTests/TR2Level_UnitTests.cs
+++ b/TRLevelReaderUnitTests/TR2Level_UnitTests.cs
@@ -491,7 +491,7 @@ namespace TRLevelReaderUnitTests
             //Set OneShot on each trigger
             foreach (FDTriggerEntry trigger in triggers)
             {
-                trigger.TrigSetup.SetOneShot();
+                trigger.TrigSetup.OneShot = true;
             }
 
             fdataReader.WriteToLevel(lvl);
@@ -516,7 +516,7 @@ namespace TRLevelReaderUnitTests
             //Switch it off again
             foreach (FDTriggerEntry trigger in triggers)
             {
-                trigger.TrigSetup.ClearOneShot();
+                trigger.TrigSetup.OneShot = false;
             }
 
             fdataReader.WriteToLevel(lvl);

--- a/TextureExport/Program.cs
+++ b/TextureExport/Program.cs
@@ -14,7 +14,7 @@ namespace TextureExport
     {
         enum Mode
         {
-            Png, Html, Segments, Faces
+            Png, Html, Segments, Faces, Boxes
         }
 
         static void Main(string[] args)
@@ -43,6 +43,14 @@ namespace TextureExport
                 else if (arg == "faces")
                 {
                     mode = Mode.Faces;
+                    if (args.Length < 3)
+                    {
+                        return;
+                    }
+                }
+                else if (arg == "boxes")
+                {
+                    mode = Mode.Boxes;
                     if (args.Length < 3)
                     {
                         return;
@@ -98,6 +106,9 @@ namespace TextureExport
                 case Mode.Faces:
                     new FaceMapper(inst).GenerateFaces(lvl.ToLower().Replace(".tr2", "_faced.tr2"), GetFaceRoomArgs());
                     break;
+                case Mode.Boxes:
+                    new FaceMapper(inst).GenerateBoxes(lvl.ToLower().Replace(".tr2", "_boxed.tr2"), GetFaceRoomArgs());
+                    break;
                 default:
                     ExportAllTexturesToPng(lvl, inst);
                     break;
@@ -148,7 +159,7 @@ namespace TextureExport
         static void Usage()
         {
             Console.WriteLine();
-            Console.WriteLine("Usage: TextureExport [orig | gold | *.tr2] [png | html | segments]");
+            Console.WriteLine("Usage: TextureExport [orig | gold | *.tr2] [png | html | segments | faces | boxes]");
             Console.WriteLine();
 
             Console.WriteLine("Target Levels");
@@ -162,6 +173,7 @@ namespace TextureExport
             Console.WriteLine("\thtml     - Export all tiles to a single HTML document.");
             Console.WriteLine("\tsegments - Export each object and sprite texture to individual PNG files.");
             Console.WriteLine("\tfaces    - Creates a new texture for every face in a room and marks its index (output is LVL_faced.tr2).");
+            Console.WriteLine("\tboxes    - Similar to faces, but marks box extents for a list of rooms (output is LVL_boxed.tr2).");
             Console.WriteLine();
             
             Console.WriteLine("Examples");
@@ -200,6 +212,13 @@ namespace TextureExport
             Console.WriteLine("\tTextureExport WALL.TR2 faces 4,32");
             Console.ResetColor();
             Console.WriteLine("\t\tCreates a new texture for every face in rooms 4 and 32 and marks its index on the texture.");
+            Console.WriteLine("\t\tThe level will likely be unplayable due to limits but can be viewed in trview.");
+            Console.WriteLine();
+
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine("\tTextureExport WALL.TR2 boxes 4,32");
+            Console.ResetColor();
+            Console.WriteLine("\t\tCreates a new texture for sectors in rooms 4 and 32, showing the box index for the sector.");
             Console.WriteLine("\t\tThe level will likely be unplayable due to limits but can be viewed in trview.");
             Console.WriteLine();
         }

--- a/TextureExport/TextureExport.csproj
+++ b/TextureExport/TextureExport.csproj
@@ -12,6 +12,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\TRFDControl\TRFDControl.csproj" />
     <ProjectReference Include="..\TRLevelReader\TRLevelReader.csproj" />
     <ProjectReference Include="..\TRModelTransporter\TRModelTransporter.csproj" />
     <ProjectReference Include="..\TRTexture16Importer\TRTexture16Importer.csproj" />


### PR DESCRIPTION
# AI Pathfinding
This PR is aimed at resolving enemy AI pathfinding issues introduced with the environment changes in V1.4.0. The problems were a result of the platforms created by `EMFloorFunction`. When creating these, a new `TR2Box` is created to avoid non-climber enemies teleporting on top of the platforms, and for every box there has to be a corresponding `TR2Zone`. The previous release was creating these zones (10 ushorts) by just appending to the end of the existing list, but zone values are not actually sequential. So the new zones were in fact corrupting other boxes in the levels, which is why enemy behaviour was strange in various places.

## Zones
The `ushort[]` was previously being parsed sequentially to build the `TR2Zone` objects. The values are in fact organised as follows.
- `NumBoxes x 4 ushort` <ins>ground</ins> zone values for the level with flipmap <ins>off</ins>;
- `NumBoxes x 1 ushort` <ins>fly</ins> zone value for the level with flipmap <ins>off</ins>;
- `NumBoxes x 4 ushort` <ins>ground</ins> zone values for the level with flipmap <ins>on</ins>;
- `NumBoxes x 1 ushort` <ins>fly</ins> zone value for the level with flipmap <ins>on</ins>.

To build objects from this structure, the following enums have been created.
- `TRLevelReader.Model.Base.Enums.FlipStatus` (Off, On)
- `TRLevelReader.Model.TR2.Enums.TR2Zones` (Zone1 - Zone4)

`TR2Zone` now contains a map of `TR2Zones` to ushort values for the ground zones, and a separate fly zone value. `TR2ZoneGroup` is a new class, which contains a `TR2Zone` for the flipmap off values, and another for flipmap on. `TR2Level` contains an array of `TR2ZoneGroup` objects, and the length of this array matches the number of boxes, which means we can access the zoning for any given box index.

### I/O
`TR2LevelReader` has been reverted to read the full zone `ushort[]` in one go, but will now pass this to `TR2BoxUtilities`, which will build the `TR2ZoneGroup` objects. This takes into account the flip status and zone order. This utility class has a similar method to flatten the zone groups into a `ushort[]` for writing back to the level.

### Adding Zones
When adding a zone after raising a platform, we just duplicate the values from the zone of the previous box we are raising from. I don't know exactly what the zone values represent, but I think they are related to different enemy types and whether or not they can "use" the box. `TR2BoxUtilities` has a method to duplicate a zone for convenience, but adding to the level's array is done just like any other areas we change.

### Other TR Versions
TR1 would need its own `TRZones` enum (Zone1 - Zone2) and a similar change to `TRZone` and a `TRZoneGroup` created. From my understanding, TR3-5 use the same setup as TR2. For now, the zoning changes have only been made for TR2, so the others still use the raw `ushort[]`.

## Overlaps
Every box can have a list of other boxes that are linked to it, and I believe this is used in the pathfinding algorithm together with the zone values for the boxes. A good example is the Catacombs initial yeti room (room 74) and the issue here when a non-climber enemy, such as a masked goon is in the room. They run against the corner because the box here has an overlap into the box in the room next door (room 35). I believe this is a bug in the way the overlaps were originally built, because these rooms have overlapping geometry. So these non-climber enemies think they can reach Lara by taking the long way around, but obviously the wall blocks them. They are blocked from climbing the steps to reach Lara because of the zoning against these boxes I believe, so rather than entering a bored mood, they continue to try the long route to reach Lara. When Lara moves into the room, they change their pathing as she is now in the same box (or in a box the enemy can make an easier path to). For climber enemies - yetis, stick goons, etc - they _can_ make their way up the steps because the zoning matches their abilities, so they never enter the corner-running mode: they always have a better path to reach Lara.

The overlap index on each box points into the level's `Overlaps[]` and the values there are read until a value with the `0x8000` bit set is found. The box overlap index can also have a Blocked and Blockable bit set so these are also taken into account. `TR2BoxUtilities` handles reading and writing overlaps for boxes. For adding overlaps to a box, this obviously offsets all the indices above where we are adding, but the utility class will deal with resetting the overlap indices for other boxes (also taking Blockable and Blocked into account).

When creating platforms, `EMFloorFunction` will add the new box index created for the platform as an overlap to each of the boxes that are linked to the box from which we are raising/lowering the floor. The new box will contain an overlap only to the box it originated from.

So for example, if we start with:

```
Box: 121
Overlaps: 122, 123

Box: 122
Overlaps: 121, 123

Box: 123
Overlaps: 121, 122
```

and then add a new box positioned on a sector in box 123, we would then have:

```
Box: 999
Overlaps: 123

Box: 121
Overlaps: 122, 123, 999

Box: 122
Overlaps: 121, 123, 999

Box: 123
Overlaps: 121, 122, 999
```

### Usage
As well as `EMFloorFunction` updating overlaps as needed when platforms are raised/lowered, a new function has been added - `EMModifyOverlapsFunction`. This allows us to fix the Catacombs yeti room by removing the invalid overlaps here. So now if the likes of a masked goon is in the room, and Lara is further up the steps, he will run around and even shoot from below instead of trying to walk through the wall.

## Testing
Unit testing has been completed for zoning and overlaps. For zones, we store the serialized form of each mapped against its box, make an addition to the boxes/zones, and then verify that the serialized data still matches i.e. the only thing affected by the addition was the addition itself.

For overlaps, we map every box with its overlap list and initially write everything back making no changes to check that the box overlap index values are the same and that the overlap array itself is the same. We then add a new overlap to a box and confirm that the overlap list for each box remains the same, other than the one updated.

For the Catacombs corner, each potential enemy type that can be in this room has been manually tested.

# FDControl
Update to `FDTrigSetup` to allow setting the `OneShot` property directly so that environment JSON can set this flag (it was previously implemented as methods). Unit testing has been updated for this as well as the current callers (`EnemyUtilities` and `BaseMoveTriggerableFunction`).

# #49 Environment Randomization
The following amendments to general environment randomization for levels have been made.
- Moved a random raised platform in The Deck to avoid slope softlock.
- Update to Catacombs for the music/enemy trigger on entering the Ice Palace area to set the trigger as OneShot, otherwise the music plays on the return path as well.
- Added the possibility of an alternate ending to Offshore Rig, making use of the DA rooms. This includes an update to `EMRemoveTriggerFunction` to allow clearing a room entirely of triggers, which we do here to remove the underwater current triggers from the DA room. This isn't strictly necessary after draining but is tidier than leaving them.
- More keyhole, switch and lever randomized locations added for Venice, Bartoli's and Opera House.
- New room opened in Bartoli's.
- Water sound sources are now removed in DA when draining rooms.
- Amendment to Wreck to always add the ladder to get back to the piston room (All category). AllWithin contains the other options (flooding and completely draining), but the ladder will always be there.
- Additional locations for the storage keyhole in the Deck to reduce the odds of the keyhole being changed into a switch (previously there were only 3 options).
- Fixes a potential issue with a glitched secret in Tibet after flooding room 50. Flooding would make it possible to get it without glitching, so if a secret is found here before flooding, it will be moved to another glitched location.
- Some additional flooding/draining options for the end of Tibet.
- Fixes an issue in `EMConvertEnemyFunction` that could have resulted in an alias enemy being selected when switching from land to water creature or vice-versa.

# Misc
- `TextureExport` now has an option to draw box numbers and overlaps on floor sectors as a way to visualise box extents. This is similar to how it draws face indices. The overlap list is best inspected in code as the list can be long, but it is useful for showing where boxes themselves are.
- New level name added (English only) for Tibetan Foothills (credit to PyroGXPilot).
