### PR TITLE
Add item difficulty option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,55 @@
 # TR2-Rando
-Tomb Raider II Item Randomizer
-
-# Discord
-[Randomizer Discord](https://discord.gg/f4bUqwgcCN)
+Tomb Raider II Game Randomizer
 
 ![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando.PNG)
 
-# NuGet Packages
+# Features
+![TR2 Rando UI](https://github.com/DanzaG/TR2-Rando/blob/master/UI.png)
+
+* **Secrets** - Randomizes locations of secrets and their rewards.
+* **Items** - Randomizes pickups, including key items!
+* **Enemies** - Randomizes the types of enemies you encounter.
+* **Textures** - Randomly applies textures to levels.
+* **Level Sequencing** - Change the number of levels in the game and randomize their order.
+* **Inventory Loss** - Randomizes what levels Lara loses her guns and/or ammo and items.
+* **Audio** - Randomizes title screen, level ambience, trigger and secret soundtracks.
+* **Sunsets** - Randomizes what levels have the Bartoli's Hideout sunset effect.
+* **Outfits** - Randomizes the outfit Lara wears in each level, including options like invisibility and haircuts.
+* **Text** - Randomizes in-game text, such as weapon and level names. Includes a variety of languages to choose from.
+* **Night Mode** - Darken levels to give a night-time effect.
+* **Starting Position** - Choose to have Lara start levels in different positions facing a different direction.
+* **Environment** - Modifies the level environment, such as mixing up water levels, mirroring levels and moving keyholes.
+* And more!
+
+# Getting Started
+1. Download the latest version at https://github.com/DanzaG/TR2-Rando/releases. Make sure to download the zip and not the source code.
+2. Extract.
+3. Run "TR2Randomizer.exe" and follow the instructions.
+4. Play and enjoy!
+
+# Discord
+We have a friendly community Discord server [here](https://discord.gg/f4bUqwgcCN).
+
+# Tracker
+For keeping track of levels while you play, check out the [TR2RandoTracker](https://github.com/lahm86/TR2RandoTracker).
+
+# Screenies
+![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando2.PNG)
+![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando3.PNG)
+![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando4.PNG)
+![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando5.PNG)
+![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando6.PNG)
+![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando7.PNG)
+![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando8.PNG)
+
+# Development
+You will need the following dependencies:
+
+### NuGet Packages
 * https://github.com/icsharpcode/SharpZipLib - Used for Zlib functions.
 * https://github.com/JamesNK/Newtonsoft.Json - Serialization/de-serialization of data.
 
-# Additional Build Dependencies
-In addition to Newtonsoft.JSON, the following dependencies external to NuGet are required to build:
+### Additional Build Dependencies
 * https://github.com/lahm86/TRGameflowEditor/releases/latest - TRGameflowEditor by Lahm.
 * https://github.com/lahm86/RectanglePacker/releases/latest - ReactanglePacker by Lahm.
 
@@ -41,39 +79,3 @@ In addition to Newtonsoft.JSON, the following dependencies external to NuGet are
     * Fetch (Russian)
     * Riku (Finnish)
 
-![TR2 Rando UI](https://github.com/DanzaG/TR2-Rando/blob/master/UI.png)
-
-# Types
-* Secrets - Randomizes locations of secrets, they are ordered based on casual play order, so you should expect to find a stone before jade.
-* Items - Randomizes pickups, including key items!
-* Enemies - Randomizes the types of enemies you encounter. The enemy types encountered in elevels can also be randomized (cross-level enemies).
-* Textures - Randomly applies textures to a level. Persistent textures can also be set to enable consistency of textures between groups of levels.
-* Level count and sequencing - Randomizes the number of levels in the game and their order.
-* Secrets Rewards - Randomizes what you get from the collect all secrets rewards.
-* Unarmed Levels - Randomizes what levels lara's guns get removed.
-* Audio Tracks - Randomizes title screen, level ambience, trigger and secret soundtracks.
-* Ammo Loss - Randomizes what levels Lara's ammo and items get removed.
-* Sunsets - Randomizes what levels have bartoli sunset effect.
-* Outfits - Randomizes the outfit Lara wears in each level, including an invisibility option, and randomly cuts Lara's hair.
-* Text - Randomizes in-game text, such as weapon and level names. Including a variety of languages to choose from.
-* Night Mode - Darkens a chosen number of levels to give a night-time effect.
-* Starting Position - Choose to have Lara start levels in different positions and facing a different direction.
-* Environment - Modifies the level environment, such as mixing up water levels, mirroring levels and moving keyholes.
-
-# Download
-https://github.com/DanzaG/TR2-Rando/releases/download/V1.4.1/V1.4.1.zip
-
-# Installation
-https://www.youtube.com/watch?v=MpNBfZgE0Fc
-
-# Tracker
-For keeping track of levels while you play, check out the [TR2RandoTracker](https://github.com/lahm86/TR2RandoTracker/releases/latest).
-
-# Screenies
-![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando2.PNG)
-![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando3.PNG)
-![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando4.PNG)
-![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando5.PNG)
-![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando6.PNG)
-![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando7.PNG)
-![TR2 Rando](https://github.com/DanzaG/TR2-Rando/blob/master/rando8.PNG)

--- a/TR2RandomizerCore/Helpers/ItemDifficulty.cs
+++ b/TR2RandomizerCore/Helpers/ItemDifficulty.cs
@@ -1,0 +1,7 @@
+﻿namespace TR2RandomizerCore.Helpers
+{
+    public enum ItemDifficulty
+    {
+        Default, OneLimit
+    }
+}

--- a/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
@@ -93,7 +93,6 @@ namespace TR2RandomizerCore.Randomizers
             }
         }
 
-        // roomNumber is specified if ONLY that room is to be populated
         private void PlaceAllItems(List<Location> locations, TR2Entities entityToAdd = TR2Entities.LargeMed_S_P, bool transformToLevelSpace = true)
         {
             List<TR2Entity> ents = _levelInstance.Data.Entities.ToList();
@@ -396,29 +395,27 @@ namespace TR2RandomizerCore.Randomizers
             //Is there something in the unarmed level pistol location?
             if (_unarmedLevelPistolIndex != -1)
             {
-                List<TR2Entities> ReplacementWeapons = TR2EntityUtilities.GetListOfGunTypes();
-                ReplacementWeapons.Add(TR2Entities.Pistols_S_P);
+                List<TR2Entities> replacementWeapons = TR2EntityUtilities.GetListOfGunTypes();
+                replacementWeapons.Add(TR2Entities.Pistols_S_P);
+                TR2Entities weaponType = replacementWeapons[_generator.Next(0, replacementWeapons.Count)];
 
-                TR2Entities Weap = ReplacementWeapons[_generator.Next(0, ReplacementWeapons.Count)];
                 if (_levelInstance.Is(LevelNames.CHICKEN))
                 {
                     // Grenade Launcher and Harpoon cannot trigger the bells in Ice Palace
-                    while (Weap.Equals(TR2Entities.GrenadeLauncher_S_P) || Weap.Equals(TR2Entities.Harpoon_S_P))
+                    while (weaponType.Equals(TR2Entities.GrenadeLauncher_S_P) || weaponType.Equals(TR2Entities.Harpoon_S_P))
                     {
-                        Weap = ReplacementWeapons[_generator.Next(0, ReplacementWeapons.Count)];
+                        weaponType = replacementWeapons[_generator.Next(0, replacementWeapons.Count)];
                     }
                 }
-
-                TR2Entity unarmedLevelWeapons = _levelInstance.Data.Entities[_unarmedLevelPistolIndex];
 
                 uint ammoToGive = 0;
                 bool addPistols = false;
                 uint smallMediToGive = 0;
                 uint largeMediToGive = 0;
 
-                if (_startingAmmoToGive.ContainsKey(Weap))
+                if (_startingAmmoToGive.ContainsKey(weaponType))
                 {
-                    ammoToGive = _startingAmmoToGive[Weap];
+                    ammoToGive = _startingAmmoToGive[weaponType];
                     if (PerformEnemyWeighting)
                     {
                         // Create a score based on each type of enemy in this level and increase the ammo count based on this
@@ -447,20 +444,18 @@ namespace TR2RandomizerCore.Randomizers
                     }
                 }
 
-                //#68 - Provide some additional ammo for a weapon if not pistols
-                if (Weap != TR2Entities.Pistols_S_P)
-                {
-                    AddORAmmo(GetWeaponAmmo(Weap), ammoToGive, unarmedLevelWeapons);
-                }
+                TR2Entity unarmedLevelWeapons = _levelInstance.Data.Entities[_unarmedLevelPistolIndex];
+                unarmedLevelWeapons.TypeID = (short)weaponType;
 
-                unarmedLevelWeapons.TypeID = (short)Weap;
-
-                if (Weap != TR2Entities.Pistols_S_P)
+                if (weaponType != TR2Entities.Pistols_S_P)
                 {
+                    //#68 - Provide some additional ammo for a weapon if not pistols
+                    AddORAmmo(GetWeaponAmmo(weaponType), ammoToGive, unarmedLevelWeapons);
+
                     // If we haven't decided to add the pistols (i.e. for enemy difficulty)
                     // add a 1/3 chance of getting them anyway. #149 If the harpoon is being
                     // given, the pistols will be included.
-                    if (addPistols || Weap == TR2Entities.Harpoon_S_P || _generator.Next(0, 3) == 0)
+                    if (addPistols || weaponType == TR2Entities.Harpoon_S_P || _generator.Next(0, 3) == 0)
                     {
                         CopyEntity(unarmedLevelWeapons, TR2Entities.Pistols_S_P);
                     }

--- a/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/ItemRandomizer.cs
@@ -532,20 +532,18 @@ namespace TR2RandomizerCore.Randomizers
                 replacementWeapons.Add(TR2Entities.Pistols_S_P);
             }
 
-            // Pick a new weapon, but exclude the grenade launcher because it affects the kill
-            // count. Also exclude the harpoon as neither it nor the grenade launcher can break
-            // Lara's bedroom window, and the enemy there may have been randomized to one without
-            // a gun. Probably not a softlock scenario but safer to exclude for now.
+            // Pick a new weapon, but exclude the grenade launcher because it affects the kill count
             TR2Entities replacementWeapon;
             do
             {
                 replacementWeapon = replacementWeapons[_generator.Next(0, replacementWeapons.Count)];
             }
-            while (replacementWeapon == TR2Entities.GrenadeLauncher_S_P || replacementWeapon == TR2Entities.Harpoon_S_P);
+            while (replacementWeapon == TR2Entities.GrenadeLauncher_S_P);
 
             TR2Entities replacementAmmo = GetWeaponAmmo(replacementWeapon);
-            
+
             List<TR2Entity> ents = _levelInstance.Data.Entities.ToList();
+            TR2Entity harpoonWeapon = null;
             foreach (TR2Entity entity in ents)
             {
                 if (entity.Room != 57)
@@ -557,12 +555,21 @@ namespace TR2RandomizerCore.Randomizers
                 if (TR2EntityUtilities.IsGunType(entityType))
                 {
                     entity.TypeID = (short)replacementWeapon;
+
+                    if (replacementWeapon == TR2Entities.Harpoon_S_P)
+                    {
+                        harpoonWeapon = entity;
+                    }
                 }
                 else if (TR2EntityUtilities.IsAmmoType(entityType) && replacementWeapon != TR2Entities.Pistols_S_P)
                 {
                     entity.TypeID = (short)replacementAmmo;
                 }
             }
+
+            // if weapon is harpoon, spawn pistols as well (see #149)
+            if (harpoonWeapon != null)
+                CopyEntity(harpoonWeapon, TR2Entities.Pistols_S_P);
         }
 
         private void RandomizeVehicles()

--- a/TR2RandomizerCore/Randomizers/TR2LevelRandomizer.cs
+++ b/TR2RandomizerCore/Randomizers/TR2LevelRandomizer.cs
@@ -37,6 +37,7 @@ namespace TR2RandomizerCore.Randomizers
         internal bool HardSecrets { get; set; }
         internal bool IncludeKeyItems { get; set; }
         internal bool DevelopmentMode { get; set; }
+        internal ItemDifficulty RandoItemDifficulty { get; set; }
         internal bool PersistTextureVariants { get; set; }
         internal bool RetainKeySpriteTextures { get; set; }
         internal bool RetainSecretSpriteTextures { get; set; }
@@ -84,6 +85,7 @@ namespace TR2RandomizerCore.Randomizers
             RandomizeItems = config.GetBool(nameof(RandomizeItems));
             ItemSeed = config.GetInt(nameof(ItemSeed), defaultSeed);
             IncludeKeyItems = config.GetBool(nameof(IncludeKeyItems), true);
+            RandoItemDifficulty = (ItemDifficulty)config.GetEnum(nameof(RandoItemDifficulty), typeof(ItemDifficulty), ItemDifficulty.Default);
 
             RandomizeEnemies = config.GetBool(nameof(RandomizeEnemies));
             EnemySeed = config.GetInt(nameof(EnemySeed), defaultSeed);
@@ -148,6 +150,7 @@ namespace TR2RandomizerCore.Randomizers
             config[nameof(RandomizeItems)] = RandomizeItems;
             config[nameof(ItemSeed)] = ItemSeed;
             config[nameof(IncludeKeyItems)] = IncludeKeyItems;
+            config[nameof(RandoItemDifficulty)] = RandoItemDifficulty;
 
             config[nameof(RandomizeEnemies)] = RandomizeEnemies;
             config[nameof(EnemySeed)] = EnemySeed;
@@ -320,6 +323,7 @@ namespace TR2RandomizerCore.Randomizers
                         BasePath = wipDirectory,
                         SaveMonitor = monitor,
                         IncludeKeyItems = IncludeKeyItems,
+                        Difficulty = RandoItemDifficulty,
                         PerformEnemyWeighting = RandomizeEnemies && CrossLevelEnemies,
                         TextureMonitor = textureMonitor,
                         IsDevelopmentModeOn = DevelopmentMode

--- a/TR2RandomizerCore/TR2RandomizerController.cs
+++ b/TR2RandomizerCore/TR2RandomizerController.cs
@@ -287,6 +287,12 @@ namespace TR2RandomizerCore
             set => LevelRandomizer.DevelopmentMode = value;
         }
 
+        public ItemDifficulty RandoItemDifficulty
+        {
+            get => LevelRandomizer.RandoItemDifficulty;
+            set => LevelRandomizer.RandoItemDifficulty = value;
+        }
+
         public bool CrossLevelEnemies
         {
             get => LevelRandomizer.CrossLevelEnemies;

--- a/TR2RandomizerView/Controls/EditorControl.xaml
+++ b/TR2RandomizerView/Controls/EditorControl.xaml
@@ -123,16 +123,28 @@
             SeedValue="{Binding SecretSeed, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
             BoolItemsSource="{Binding SecretBoolItemControls}"/>
 
-        <ctrl:ManagedSeedBoolControl
-            Grid.Row="1" 
+        <ctrl:ManagedSeedAdvancedControl
+            Grid.Row="1"
             Grid.Column="1"
             IsActive="{Binding RandomizeItems, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
             Title="Randomize Items"
-            Text="Randomize standard pickups in each level."
+            Text="Randomize the items in each level."
             SeedMinValue="1"
             SeedMaxValue="{Binding MaxSeedValue}"
-            SeedValue="{Binding ItemSeed, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
-            BoolItemsSource="{Binding ItemBoolItemControls}"/>
+            SeedValue="{Binding ItemSeed, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+            <ctrl:ManagedSeedAdvancedControl.Resources>
+                <cvt:BindingProxy x:Key="proxy" Data="{Binding}" />
+            </ctrl:ManagedSeedAdvancedControl.Resources>
+            <ctrl:ManagedSeedAdvancedControl.AdvancedWindowToOpen>
+                <windows:AdvancedWindow Title="Randomize Items (Advanced)"
+                                        MainDescription="Customize the item randomization."
+                                        BoolItemsSource="{Binding Data.ItemBoolItemControls, Source={StaticResource proxy}}"
+                                        HasBoolItems="True"
+                                        HasItemDifficulty="True"
+                                        ControllerProxy="{Binding Data, Source={StaticResource proxy}}">
+                </windows:AdvancedWindow>
+            </ctrl:ManagedSeedAdvancedControl.AdvancedWindowToOpen>
+        </ctrl:ManagedSeedAdvancedControl>
 
         <ctrl:ManagedSeedAdvancedControl
             Grid.Row="2"

--- a/TR2RandomizerView/Model/ControllerOptions.cs
+++ b/TR2RandomizerView/Model/ControllerOptions.cs
@@ -43,6 +43,7 @@ namespace TR2RandomizerView.Model
         private List<BoolItemControlClass> _secretBoolItemControls, _itemBoolItemControls, _enemyBoolItemControls, _textureBoolItemControls, _audioBoolItemControls, _outfitBoolItemControls, _textBoolItemControls, _startBoolItemControls, _environmentBoolItemControls;
 
         private RandoDifficulty _randoEnemyDifficulty;
+        private ItemDifficulty _randoItemDifficulty;
 
         private Language[] _availableLanguages;
         private Language _gameStringLanguage;
@@ -386,6 +387,16 @@ namespace TR2RandomizerView.Model
             set
             {
                 _includeKeyItems = value;
+                FirePropertyChanged();
+            }
+        }
+
+        public ItemDifficulty RandoItemDifficulty
+        {
+            get => _randoItemDifficulty;
+            set
+            {
+                _randoItemDifficulty = value;
                 FirePropertyChanged();
             }
         }
@@ -1119,6 +1130,7 @@ namespace TR2RandomizerView.Model
             RandomizeItems = _controller.RandomizeItems;
             ItemSeed = _controller.ItemSeed;
             IncludeKeyItems.Value = _controller.IncludeKeyItems;
+            RandoItemDifficulty = _controller.RandoItemDifficulty;
 
             RandomizeEnemies = _controller.RandomizeEnemies;
             EnemySeed = _controller.EnemySeed;
@@ -1359,6 +1371,7 @@ namespace TR2RandomizerView.Model
             _controller.RandomizeItems = RandomizeItems;
             _controller.ItemSeed = ItemSeed;
             _controller.IncludeKeyItems = IncludeKeyItems.Value;
+            _controller.RandoItemDifficulty = RandoItemDifficulty;
 
             _controller.RandomizeEnemies = RandomizeEnemies;
             _controller.EnemySeed = EnemySeed;

--- a/TR2RandomizerView/Windows/AdvancedWindow.xaml
+++ b/TR2RandomizerView/Windows/AdvancedWindow.xaml
@@ -51,6 +51,12 @@
                     <Setter Property="Margin"
                             Value="40,0,0,0" />
                 </Style>
+                <Style TargetType="{x:Type StackPanel}">
+                    <Setter Property="Margin"
+                            Value="0, 5, 0, 10" />
+                    <Setter Property="Grid.ColumnSpan"
+                            Value="2" />
+                </Style>
             </Grid.Resources>
             
             <Grid.RowDefinitions>
@@ -76,11 +82,8 @@
                 Grid.ColumnSpan="2"
                 Margin="0,0,0,10"/>
 
+            <!-- General -->
             <StackPanel Grid.Row="1"
-                        Grid.ColumnSpan="2"
-                        Orientation="Vertical"
-                        HorizontalAlignment="Left"
-                        Margin="0,0,0,10"
                         Visibility="{Binding HasBoolItems, Converter={StaticResource BoolToCollapsedConverter}}">
                 <TextBlock Style="{StaticResource HeaderStyle}"
                            Text="General"/>
@@ -119,9 +122,8 @@
                 </ItemsControl>
             </StackPanel>
 
+            <!-- (Enemy) Difficulty -->
             <StackPanel Grid.Row="2"
-                        Grid.ColumnSpan="2"
-                        Margin="0,5,0,0"
                         Visibility="{Binding HasDifficulty, Converter={StaticResource BoolToCollapsedConverter}}">
                 <StackPanel.Resources>
                     <cvt:ComparisonConverter x:Key="ComparisonConverter" />
@@ -180,9 +182,8 @@
                 </Grid>
             </StackPanel>
 
+            <!-- Language -->
             <StackPanel Grid.Row="3"
-                        Grid.ColumnSpan="2"
-                        Margin="0,5,0,0"
                         Visibility="{Binding HasLanguage, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -209,9 +210,8 @@
                 </Grid>
             </StackPanel>
 
+            <!-- Mirrored Levels -->
             <StackPanel Grid.Row="4"
-                        Grid.ColumnSpan="2"
-                        Margin="0,5,0,0"
                         Visibility="{Binding HasMirroring, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -264,9 +264,8 @@
                 </Grid>
             </StackPanel>
 
+            <!-- Haircuts -->
             <StackPanel Grid.Row="5"
-                        Grid.ColumnSpan="2"
-                        Margin="0,5,0,0"
                         Visibility="{Binding HasHaircuts, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -319,9 +318,8 @@
                 </Grid>
             </StackPanel>
 
+            <!-- Invisibility -->
             <StackPanel Grid.Row="6"
-                        Grid.ColumnSpan="2"
-                        Margin="0,15,0,0"
                         Visibility="{Binding HasInvisibility, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -374,8 +372,8 @@
                 </Grid>
             </StackPanel>
 
+            <!-- Night Mode general -->
             <StackPanel Grid.Row="7"
-                        Grid.ColumnSpan="2"
                         Visibility="{Binding HasNightMode, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -428,9 +426,8 @@
                 </Grid>
             </StackPanel>
 
+            <!-- Intensity -->
             <StackPanel Grid.Row="8"
-                        Grid.ColumnSpan="2"
-                        Margin="0,15,0,0"
                         Visibility="{Binding HasNightMode, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"

--- a/TR2RandomizerView/Windows/AdvancedWindow.xaml
+++ b/TR2RandomizerView/Windows/AdvancedWindow.xaml
@@ -122,6 +122,59 @@
                 </ItemsControl>
             </StackPanel>
 
+            <!-- (Item) Difficulty -->
+            <StackPanel Grid.Row="2"
+                        Visibility="{Binding HasItemDifficulty, Converter={StaticResource BoolToCollapsedConverter}}">
+                <StackPanel.Resources>
+                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
+                </StackPanel.Resources>
+
+                <TextBlock Style="{StaticResource HeaderStyle}"
+                           Text="Difficulty" />
+
+                <Grid Margin="0,5,0,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="SSG1" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border>
+                        <RadioButton Content="Default"
+                                     GroupName="randoItemDifficulty"
+                                     x:Name="_defaultItemDifficultyButton"
+                                     VerticalAlignment="Center"
+                                     Padding="4,0,0,0"
+                                     IsChecked="{Binding ControllerProxy.RandoItemDifficulty, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static helpers:ItemDifficulty.Default}, Mode=TwoWay}" />
+                    </Border>
+
+                    <Border Grid.Row="0"
+                            Grid.Column="1">
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Standard item randomization." />
+                    </Border>
+
+                    <Border Grid.Row="1"
+                            Grid.Column="0">
+                        <RadioButton Content="One Limit"
+                                     GroupName="randoItemDifficulty"
+                                     x:Name="_itemOneLimitButton"
+                                     VerticalAlignment="Center"
+                                     Padding="4,0,0,0"
+                                     IsChecked="{Binding ControllerProxy.RandoItemDifficulty, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static helpers:ItemDifficulty.OneLimit}, Mode=TwoWay}" />
+                    </Border>
+
+                    <Border Grid.Row="1"
+                            Grid.Column="1">
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Each item type will spawn a maximum of once per level." />
+                    </Border>
+                </Grid>
+            </StackPanel>
+
             <!-- (Enemy) Difficulty -->
             <StackPanel Grid.Row="2"
                         Visibility="{Binding HasDifficulty, Converter={StaticResource BoolToCollapsedConverter}}">

--- a/TR2RandomizerView/Windows/AdvancedWindow.xaml
+++ b/TR2RandomizerView/Windows/AdvancedWindow.xaml
@@ -227,7 +227,7 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <Border>
+                    <Border Margin="0,3,0,0">
                         <StackPanel Orientation="Horizontal" 
                                     HorizontalAlignment="Left">
                             <Label Content="Number of levels"
@@ -281,7 +281,7 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <Border>
+                    <Border Margin="0,3,0,0">
                         <StackPanel Orientation="Horizontal" 
                                     HorizontalAlignment="Left">
                             <Label Content="Number of levels"
@@ -335,7 +335,7 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <Border>
+                    <Border Margin="0,3,0,0">
                         <StackPanel Orientation="Horizontal" 
                                     HorizontalAlignment="Left">
                             <Label Content="Number of levels"
@@ -389,7 +389,7 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <Border>
+                    <Border Margin="0,3,0,0">
                         <StackPanel Orientation="Horizontal" 
                                     HorizontalAlignment="Left">
                             <Label Content="Number of levels"

--- a/TR2RandomizerView/Windows/AdvancedWindow.xaml
+++ b/TR2RandomizerView/Windows/AdvancedWindow.xaml
@@ -33,6 +33,17 @@
                     <Setter Property="Margin"
                             Value="0,10,0,0" />
                 </Style>
+                <Style x:Key="OptionDescriptionStyle"
+                       TargetType="{x:Type Label}">
+                    <Setter Property="HorizontalAlignment"
+                            Value="Left" />
+                    <Setter Property="FontStyle"
+                            Value="Italic" />
+                    <Setter Property="Padding"
+                            Value="0" />
+                    <Setter Property="Margin"
+                            Value="40,0,0,0" />
+                </Style>
             </Grid.Resources>
             
             <Grid.RowDefinitions>
@@ -87,11 +98,8 @@
 
                                 <Border Grid.Column="1"
                                         Margin="0,10,0,0">
-                                    <Label HorizontalAlignment="Left"
-                                           Content="{Binding Description}"
-                                           FontStyle="Italic"
-                                           Padding="0"
-                                           Margin="40,0,0,1">
+                                    <Label Style="{StaticResource OptionDescriptionStyle}"
+                                           Content="{Binding Description}">
                                         <Label.Resources>
                                             <Style TargetType="TextBlock">
                                                 <Setter Property="TextWrapping" Value="Wrap" />
@@ -137,15 +145,17 @@
                     </Border>
 
                     <Border Grid.Column="1">
-                        <TextBlock FontStyle="Italic"
-                                   VerticalAlignment="Center"
-                                   Margin="40,0,0,0">
-                            Standard restrictions will apply for cross-level enemies. See
-                            <Hyperlink ToolTip="https://github.com/DanzaG/TR2-Rando/blob/master/TR2RandomizerCore/Resources/Documentation/ENEMIES.md" 
-                                       NavigateUri="https://github.com/DanzaG/TR2-Rando/blob/master/TR2RandomizerCore/Resources/Documentation/ENEMIES.md"
-                                       RequestNavigate="Hyperlink_RequestNavigate">GitHub</Hyperlink>
-                            for details.
-                        </TextBlock>
+                        <Label Style="{StaticResource OptionDescriptionStyle}">
+                            <Label.Content>
+                                <TextBlock>
+                                    Standard restrictions will apply for cross-level enemies. See
+                                    <Hyperlink ToolTip="https://github.com/DanzaG/TR2-Rando/blob/master/TR2RandomizerCore/Resources/Documentation/ENEMIES.md"
+                                               NavigateUri="https://github.com/DanzaG/TR2-Rando/blob/master/TR2RandomizerCore/Resources/Documentation/ENEMIES.md"
+                                               RequestNavigate="Hyperlink_RequestNavigate">GitHub</Hyperlink>
+                                    for details.
+                                </TextBlock>
+                            </Label.Content>
+                        </Label>
                     </Border>
 
                     <Border Grid.Row="1">
@@ -159,12 +169,8 @@
 
                     <Border Grid.Row="1"
                             Grid.Column="1">
-                        <Label HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Content="Disables virtually all cross-level enemy restrictions except for technical ones."
-                               FontStyle="Italic"
-                               Padding="0"
-                               Margin="40,0,0,0"/>
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Disables virtually all cross-level enemy restrictions except for technical ones."/>
                     </Border>
                 </Grid>
             </StackPanel>
@@ -193,12 +199,8 @@
                     </Border>
 
                     <Border Grid.Column="1">
-                        <Label HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Content="Select a language to use for gamestrings, or choose to use a random combination."
-                               FontStyle="Italic"
-                               Padding="0"
-                               Margin="40,0,0,0"/>
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Select a language to use for gamestrings, or choose to use a random combination."/>
                     </Border>
                 </Grid>
             </StackPanel>
@@ -239,12 +241,8 @@
                     </Border>
 
                     <Border Grid.Column="1">
-                        <Label HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Content="Reverse the geometry and item positioning in the given number of levels, creating a mirror effect."
-                               FontStyle="Italic"
-                               Padding="0"
-                               Margin="40,0,0,0"/>
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Reverse the geometry and item positioning in the given number of levels, creating a mirror effect."/>
                     </Border>
 
                     <Border Grid.Row="1">
@@ -257,12 +255,8 @@
 
                     <Border Grid.Column="1"
                             Grid.Row="1">
-                        <Label HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Content="Mirror the assault course level in addition to or separately from above."
-                               FontStyle="Italic"
-                               Padding="0"
-                               Margin="40,0,0,0"/>
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Mirror the assault course level in addition to or separately from above."/>
                     </Border>
                 </Grid>
             </StackPanel>
@@ -303,12 +297,8 @@
                     </Border>
 
                     <Border Grid.Column="1">
-                        <Label HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Content="Lara will lose her braid in the given number of levels."
-                               FontStyle="Italic"
-                               Padding="0"
-                               Margin="40,0,0,0"/>
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Lara will lose her braid in the given number of levels."/>
                     </Border>
 
                     <Border Grid.Row="1">
@@ -321,12 +311,8 @@
 
                     <Border Grid.Column="1"
                             Grid.Row="1">
-                        <Label HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Content="Give Lara a haircut in the assault course level in addition to or separately from above."
-                               FontStyle="Italic"
-                               Padding="0"
-                               Margin="40,0,0,0"/>
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Give Lara a haircut in the assault course level in addition to or separately from above."/>
                     </Border>
                 </Grid>
             </StackPanel>
@@ -367,12 +353,8 @@
                     </Border>
 
                     <Border Grid.Column="1">
-                        <Label HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Content="Lara will wear an invisibility cloak in the given number of levels. Only her shadow will be visible."
-                               FontStyle="Italic"
-                               Padding="0"
-                               Margin="40,0,0,0"/>
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Lara will wear an invisibility cloak in the given number of levels. Only her shadow will be visible."/>
                     </Border>
 
                     <Border Grid.Row="1">
@@ -385,12 +367,8 @@
 
                     <Border Grid.Column="1"
                             Grid.Row="1">
-                        <Label HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Content="Make Lara invisible in the assault course level in addition to or separately from above."
-                               FontStyle="Italic"
-                               Padding="0"
-                               Margin="40,0,0,0"/>
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Make Lara invisible in the assault course level in addition to or separately from above."/>
                     </Border>
                 </Grid>
             </StackPanel>
@@ -430,12 +408,8 @@
                     </Border>
 
                     <Border Grid.Column="1">
-                        <Label HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Content="The given number of levels will be converted to night mode."
-                               FontStyle="Italic"
-                               Padding="0"
-                               Margin="40,0,0,0"/>
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="The given number of levels will be converted to night mode."/>
                     </Border>
 
                     <Border Grid.Row="1">
@@ -448,12 +422,8 @@
 
                     <Border Grid.Column="1"
                             Grid.Row="1">
-                        <Label HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Content="Adjust the assault course level lighting in addition to or separately from above."
-                               FontStyle="Italic"
-                               Padding="0"
-                               Margin="40,0,0,0"/>
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Adjust the assault course level lighting in addition to or separately from above."/>
                     </Border>
                 </Grid>
             </StackPanel>
@@ -503,12 +473,8 @@
                     </Border>
 
                     <Border Grid.Column="1">
-                        <Label HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Content="Set the darkness intensity, ranging from dusk to full night mode."
-                               FontStyle="Italic"
-                               Padding="0"
-                               Margin="40,0,0,0"/>
+                        <Label Style="{StaticResource OptionDescriptionStyle}"
+                               Content="Set the darkness intensity, ranging from dusk to full night mode."/>
                     </Border>
 
                     <Border Grid.Row="1">

--- a/TR2RandomizerView/Windows/AdvancedWindow.xaml
+++ b/TR2RandomizerView/Windows/AdvancedWindow.xaml
@@ -33,6 +33,13 @@
                     <Setter Property="Margin"
                             Value="0,10,0,0" />
                 </Style>
+                <Style x:Key="HeaderStyle"
+                       TargetType="{x:Type TextBlock}">
+                    <Setter Property="FontSize"
+                            Value="14" />
+                    <Setter Property="TextDecorations"
+                            Value="Underline" />
+                </Style>
                 <Style x:Key="OptionDescriptionStyle"
                        TargetType="{x:Type Label}">
                     <Setter Property="HorizontalAlignment"
@@ -75,9 +82,8 @@
                         HorizontalAlignment="Left"
                         Margin="0,0,0,10"
                         Visibility="{Binding HasBoolItems, Converter={StaticResource BoolToCollapsedConverter}}">
-                <TextBlock Text="General"
-                           FontSize="14"
-                           TextDecorations="Underline" />
+                <TextBlock Style="{StaticResource HeaderStyle}"
+                           Text="General"/>
                 <ItemsControl ItemsSource="{Binding BoolItemsSource, Mode=TwoWay}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
@@ -120,10 +126,9 @@
                 <StackPanel.Resources>
                     <cvt:ComparisonConverter x:Key="ComparisonConverter" />
                 </StackPanel.Resources>
-                
-                <TextBlock Text="Difficulty"
-                           FontSize="14"
-                           TextDecorations="Underline"/>
+
+                <TextBlock Style="{StaticResource HeaderStyle}"
+                           Text="Difficulty"/>
 
                 <Grid Margin="0,5,0,0">
                     <Grid.RowDefinitions>
@@ -179,10 +184,9 @@
                         Grid.ColumnSpan="2"
                         Margin="0,5,0,0"
                         Visibility="{Binding HasLanguage, Converter={StaticResource BoolToCollapsedConverter}}">
-                
-                <TextBlock Text="Language"
-                           FontSize="14"
-                           TextDecorations="Underline"/>
+
+                <TextBlock Style="{StaticResource HeaderStyle}"
+                           Text="Language"/>
 
                 <Grid Margin="0,5,0,0">
                     <Grid.ColumnDefinitions>
@@ -209,10 +213,9 @@
                         Grid.ColumnSpan="2"
                         Margin="0,5,0,0"
                         Visibility="{Binding HasMirroring, Converter={StaticResource BoolToCollapsedConverter}}">
-                
-                <TextBlock Text="Mirrored Levels"
-                           FontSize="14"
-                           TextDecorations="Underline"/>
+
+                <TextBlock Style="{StaticResource HeaderStyle}"
+                           Text="Mirrored Levels"/>
 
                 <Grid Margin="0,5,0,0">
                     <Grid.RowDefinitions>
@@ -266,9 +269,8 @@
                         Margin="0,5,0,0"
                         Visibility="{Binding HasHaircuts, Converter={StaticResource BoolToCollapsedConverter}}">
 
-                <TextBlock Text="Haircuts"
-                           FontSize="14"
-                           TextDecorations="Underline"/>
+                <TextBlock Style="{StaticResource HeaderStyle}"
+                           Text="Haircuts"/>
 
                 <Grid Margin="0,5,0,0">
                     <Grid.RowDefinitions>
@@ -322,9 +324,8 @@
                         Margin="0,15,0,0"
                         Visibility="{Binding HasInvisibility, Converter={StaticResource BoolToCollapsedConverter}}">
 
-                <TextBlock Text="Invisibility"
-                           FontSize="14"
-                           TextDecorations="Underline"/>
+                <TextBlock Style="{StaticResource HeaderStyle}"
+                           Text="Invisibility"/>
 
                 <Grid Margin="0,5,0,0">
                     <Grid.RowDefinitions>
@@ -377,9 +378,8 @@
                         Grid.ColumnSpan="2"
                         Visibility="{Binding HasNightMode, Converter={StaticResource BoolToCollapsedConverter}}">
 
-                <TextBlock Text="General"
-                           FontSize="14"
-                           TextDecorations="Underline"/>
+                <TextBlock Style="{StaticResource HeaderStyle}"
+                           Text="General"/>
 
                 <Grid Margin="0,5,0,0">
                     <Grid.RowDefinitions>
@@ -433,9 +433,8 @@
                         Margin="0,15,0,0"
                         Visibility="{Binding HasNightMode, Converter={StaticResource BoolToCollapsedConverter}}">
 
-                <TextBlock Text="Intensity"
-                           FontSize="14"
-                           TextDecorations="Underline"/>
+                <TextBlock Style="{StaticResource HeaderStyle}"
+                           Text="Intensity"/>
 
                 <Grid Margin="0,5,0,0">
                     <Grid.RowDefinitions>

--- a/TR2RandomizerView/Windows/AdvancedWindow.xaml.cs
+++ b/TR2RandomizerView/Windows/AdvancedWindow.xaml.cs
@@ -32,6 +32,11 @@ namespace TR2RandomizerView.Windows
             nameof(HasBoolItems), typeof(bool), typeof(AdvancedWindow)
         );
 
+        public static readonly DependencyProperty HasItemDifficultyProperty = DependencyProperty.Register
+        (
+            nameof(HasItemDifficulty), typeof(bool), typeof(AdvancedWindow)
+        );
+
         public static readonly DependencyProperty HasDifficultyProperty = DependencyProperty.Register
         (
             nameof(HasDifficulty), typeof(bool), typeof(AdvancedWindow)
@@ -83,6 +88,12 @@ namespace TR2RandomizerView.Windows
         {
             get => (bool)GetValue(HasBoolItemsProperty);
             set => SetValue(HasBoolItemsProperty, value);
+        }
+
+        public bool HasItemDifficulty
+        {
+            get => (bool)GetValue(HasItemDifficultyProperty);
+            set => SetValue(HasItemDifficultyProperty, value);
         }
 
         public bool HasDifficulty
@@ -152,9 +163,14 @@ namespace TR2RandomizerView.Windows
         private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             // This should not be here, but in some cases both radio buttons can remain unchecked on load
+            // TODO: This causes opening an AdvancedWindow to automatically become "unsaved"
             if (HasDifficulty)
             {
                 _unrestrictedButton.IsChecked = !(_defaultDifficultyButton.IsChecked = ControllerProxy.RandoEnemyDifficulty == RandoDifficulty.Default);
+            }
+            if (HasItemDifficulty)
+            {
+                _itemOneLimitButton.IsChecked = !(_defaultItemDifficultyButton.IsChecked = ControllerProxy.RandoItemDifficulty == ItemDifficulty.Default);
             }
         }
 


### PR DESCRIPTION
Continues work on #108; resolves #96.
- Implements an item difficulty option with two choices
   - **Default**: same as all previous versions up to now
   - **One Limit**: each item type can spawn max once per level
- Refactors some code
- Allows the harpoon to spawn in HSH (it comes with the pistols). Even though the window is breakable, we need to give pistols to the player anyway due to #149
- Updates readme to be more intuitive and informative. I used lots of personal judgment here so feel free to continuously edit it