### PR TITLE
TR3 Preparations

### DIFF
--- a/TRRandomizerCore/Editors/TR3RandoEditor.cs
+++ b/TRRandomizerCore/Editors/TR3RandoEditor.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using TRGE.Coord;
 using TRGE.Core;
+using TRRandomizerCore.Processors;
 using TRRandomizerCore.Randomizers;
 
 namespace TRRandomizerCore.Editors
@@ -29,6 +30,8 @@ namespace TRRandomizerCore.Editors
             // Add to the target as appropriate when each randomizer is implemented. Once all
             // randomizers are implemented, just call Settings.GetSaveTarget(numLevels) per TR2.
             int target = base.GetSaveTarget(numLevels);
+
+            target += numLevels; // sequence-based processing
 
             if (Settings.RandomizeSecrets)
             {
@@ -71,6 +74,18 @@ namespace TRRandomizerCore.Editors
             {
                 (tr23ScriptEditor.Script as TR23Script).LevelSelectEnabled = true;
                 scriptEditor.SaveScript();
+            }
+
+            if (!monitor.IsCancelled)
+            {
+                monitor.FireSaveStateBeginning(TRSaveCategory.Custom, "Running level sequence checks");
+                new TR3SequenceProcessor
+                {
+                    ScriptEditor = tr23ScriptEditor,
+                    Levels = levels,
+                    BasePath = wipDirectory,
+                    SaveMonitor = monitor
+                }.Run();
             }
 
             if (!monitor.IsCancelled && Settings.RandomizeSecrets)

--- a/TRRandomizerCore/Levels/TR3CombinedLevel.cs
+++ b/TRRandomizerCore/Levels/TR3CombinedLevel.cs
@@ -62,6 +62,11 @@ namespace TRRandomizerCore.Levels
         public bool HasExposureMeter => Sequence == 16 || Sequence == 17;
 
         /// <summary>
+        /// Whether or not this level is in the sequence of original Willard.
+        /// </summary>
+        public bool IsWillardSequence => Sequence == 19;
+
+        /// <summary>
         /// Whether or not the game will account for secrets collected in this level.
         /// </summary>
         public bool HasSecrets => Script.NumSecrets > 0;

--- a/TRRandomizerCore/Processors/TR3/TR3SequenceProcessor.cs
+++ b/TRRandomizerCore/Processors/TR3/TR3SequenceProcessor.cs
@@ -1,0 +1,171 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using TREnvironmentEditor;
+using TREnvironmentEditor.Model;
+using TRGE.Core;
+using TRLevelReader.Helpers;
+using TRLevelReader.Model;
+using TRLevelReader.Model.Enums;
+using TRModelTransporter.Transport;
+using TRRandomizerCore.Helpers;
+using TRRandomizerCore.Levels;
+
+namespace TRRandomizerCore.Processors
+{
+    public class TR3SequenceProcessor : TR3LevelProcessor
+    {
+        private static readonly int _entityLimit = 256;
+
+        private static readonly Dictionary<TR3Entities, TR3Entities> _artefactAssignment = new Dictionary<TR3Entities, TR3Entities>
+        {
+            [TR3Entities.Infada_P] = TR3Entities.Key1_P,
+            [TR3Entities.OraDagger_P] = TR3Entities.Key2_P,
+            [TR3Entities.EyeOfIsis_P] = TR3Entities.Key3_P,
+            [TR3Entities.Element115_P] = TR3Entities.Key4_P,
+            [TR3Entities.Infada_M_H] = TR3Entities.Key1_M_H,
+            [TR3Entities.OraDagger_M_H] = TR3Entities.Key2_M_H,
+            [TR3Entities.EyeOfIsis_M_H] = TR3Entities.Key3_M_H,
+            [TR3Entities.Element115_M_H] = TR3Entities.Key4_M_H,
+        };
+
+        private Dictionary<string, List<Location>> _upvLocations;
+
+        public void Run()
+        {
+            _upvLocations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR3\Locations\upv_locations.json"));
+
+            foreach (TR3ScriptedLevel lvl in Levels)
+            {
+                LoadLevelInstance(lvl);
+
+                AdjustLevel(_levelInstance);
+
+                SaveLevelInstance();
+
+                if (!TriggerProgress())
+                {
+                    break;
+                }
+            }
+        }
+
+        private void AdjustLevel(TR3CombinedLevel level)
+        {
+            if (level.HasExposureMeter)
+            {
+                if (!level.Is(TR3LevelNames.ANTARC) && !level.Is(TR3LevelNames.RXTECH))
+                {
+                    // The UPV keeps Lara warm underwater so make this available for
+                    // those levels that have long underwater sections.
+                    ImportUPV(level);
+                }
+            }
+
+            if (level.Is(TR3LevelNames.WILLIE))
+            {
+                if (!level.IsWillardSequence)
+                {
+                    // Picking-up the artefacts will end the level for all sequences != 19 so
+                    // re-assign the items as keys, which Cavern doesn't use.
+                    AmendWillardBoss(level);
+                }
+            }
+            else if (level.IsWillardSequence)
+            {
+                // Because the stones don't end the level on sequence 19, make any required mods
+                // to make end level triggers.
+                AmendBossFight(level);
+            }
+        }
+
+        private void ImportUPV(TR3CombinedLevel level)
+        {
+            if (!_upvLocations.ContainsKey(level.Name) || _upvLocations[level.Name].Count == 0)
+            {
+                return;
+            }
+
+            TR3ModelImporter importer = new TR3ModelImporter
+            {
+                Level = level.Data,
+                LevelName = level.Name,
+                EntitiesToImport = new List<TR3Entities> { TR3Entities.UPV },
+                DataFolder = GetResourcePath(@"TR3\Models")
+            };
+
+            importer.Import();
+
+            List<TR2Entity> entities = level.Data.Entities.ToList();
+            foreach (Location location in _upvLocations[level.Name])
+            {
+                if (entities.Count == _entityLimit)
+                {
+                    break;
+                }
+
+                entities.Add(new TR2Entity
+                {
+                    TypeID = (short)TR3Entities.UPV,
+                    Room = (short)location.Room,
+                    X = location.X,
+                    Y = location.Y,
+                    Z = location.Z,
+                    Angle = location.Angle,
+                    Flags = 0,
+                    Intensity1 = -1,
+                    Intensity2 = -1
+                });
+            }
+
+            level.Data.Entities = entities.ToArray();
+            level.Data.NumEntities = (uint)entities.Count;
+        }
+
+        private void AmendWillardBoss(TR3CombinedLevel level)
+        {
+            List<TR2Entity> entities = level.Data.Entities.ToList();
+            List<TRModel> models = level.Data.Models.ToList();
+
+            // Add new duplicate models for keys, so secret rando doesn't replace the originals.
+            foreach (TR3Entities artefact in _artefactAssignment.Keys)
+            {
+                TR3Entities replacement = _artefactAssignment[artefact];
+                TRModel artefactModel = models.Find(m => m.ID == (uint)artefact);
+                models.Add(new TRModel
+                {
+                    Animation = artefactModel.Animation,
+                    FrameOffset = artefactModel.FrameOffset,
+                    ID = (uint)replacement,
+                    MeshTree = artefactModel.MeshTree,
+                    NumMeshes = artefactModel.NumMeshes,
+                    StartingMesh = artefactModel.StartingMesh
+                });
+
+                entities.FindAll(e => e.TypeID == (short)artefact).ForEach(e => e.TypeID = (short)replacement);
+            }
+
+            // Copy the artefact names into the keys
+            for (int i = 0; i < 4; i++)
+            {
+                level.Script.Keys[i] = ScriptEditor.Script.GameStrings1[80 + i];
+            }
+
+            level.Data.Models = models.ToArray();
+            level.Data.NumModels = (uint)models.Count;
+
+            // Apply any changes needed for the boss fight
+            AmendBossFight(level);
+        }
+
+        private void AmendBossFight(TR3CombinedLevel level)
+        {
+            string mappingPath = @"TR3\BossMapping\" + level.Name + "-BossMapping.json";
+            if (ResourceExists(mappingPath))
+            {
+                EMEditorSet mods = JsonConvert.DeserializeObject<EMEditorSet>(ReadResource(mappingPath), EMEditorMapping.Converter);
+                mods.ApplyToLevel(level.Data);
+            }
+        }
+    }
+}

--- a/TRRandomizerCore/Resources/TR2/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR2/Locations/item_locations.json
@@ -113853,10 +113853,10 @@
       "IsItem": true
     },
     {
-      "X": 69127,
-      "Z": 56817,
+      "X": 64000,
+      "Z": 55808,
       "Y": 0,
-      "Room": 70,
+      "Room": 69,
       "RequiresGlitch": false,
       "Difficulty": 0,
       "IsInRoomSpace": false,
@@ -113873,10 +113873,10 @@
       "IsItem": true
     },
     {
-      "X": 69102,
-      "Z": 58886,
+      "X": 60928,
+      "Z": 54784,
       "Y": 0,
-      "Room": 70,
+      "Room": 69,
       "RequiresGlitch": false,
       "Difficulty": 0,
       "IsInRoomSpace": false,
@@ -113893,10 +113893,10 @@
       "IsItem": true
     },
     {
-      "X": 69093,
-      "Z": 60909,
+      "X": 69120,
+      "Z": 54784,
       "Y": 0,
-      "Room": 70,
+      "Room": 69,
       "RequiresGlitch": false,
       "Difficulty": 0,
       "IsInRoomSpace": false,

--- a/TRRandomizerCore/Resources/TR3/BossMapping/AREA51.TR2-BossMapping.json
+++ b/TRRandomizerCore/Resources/TR3/BossMapping/AREA51.TR2-BossMapping.json
@@ -1,0 +1,45 @@
+[
+  {
+    "Comments": "Get rid of the MP trigger under the artefact.",
+    "EMType": 62,
+    "Locations": [
+      {
+        "X": 44544,
+        "Y": -7424,
+        "Z": 35328,
+        "Room": 18
+      }
+    ]
+  },
+
+  {
+    "Comments": "Add a trigger under the artefact so that picking it up will end the level.",
+    "EMType": 61,
+    "TriggerEntry": {
+      "Setup": {
+        "Value": 4
+      },
+      "TrigSetup": {
+        "Value": 15872
+      },
+      "TrigType": 4,
+      "TrigActionList": [
+        {
+          "TrigAction": 0,
+          "Parameter": 44
+        },
+        {
+          "TrigAction": 7
+        }
+      ]
+    },
+    "Locations": [
+      {
+        "X": 44544,
+        "Y": -7424,
+        "Z": 35328,
+        "Room": 18
+      }
+    ]
+  }
+]

--- a/TRRandomizerCore/Resources/TR3/BossMapping/CHAMBER.TR2-BossMapping.json
+++ b/TRRandomizerCore/Resources/TR3/BossMapping/CHAMBER.TR2-BossMapping.json
@@ -1,0 +1,42 @@
+[
+  {
+    "Comments": "Convert Willie into a gun enemy.",
+    "EMType": 45,
+    "EntityIndex": 22,
+    "NewEntityType": 40
+  },
+
+  {
+    "Comments": "Create another couple of enemies.",
+    "EMType": 45,
+    "EntityIndex": 16,
+    "NewEntityType": 40
+  },
+
+  {
+    "EMType": 45,
+    "EntityIndex": 18,
+    "NewEntityType": 40
+  },
+
+  {
+    "Comments": "Amend the trigger under Lara to activate the new enemies.",
+    "EMType": 68,
+    "Location": {
+      "X": 61952,
+      "Y": -512,
+      "Z": 62976,
+      "Room": 5
+    },
+    "ActionItems": [
+      {
+        "TrigAction": 0,
+        "Parameter": 16
+      },
+      {
+        "TrigAction": 0,
+        "Parameter": 18
+      }
+    ]
+  }
+]

--- a/TRRandomizerCore/Resources/TR3/BossMapping/OFFICE.TR2-BossMapping.json
+++ b/TRRandomizerCore/Resources/TR3/BossMapping/OFFICE.TR2-BossMapping.json
@@ -1,0 +1,95 @@
+[
+  {
+    "Comments": "Move the artefact away from Sophia.",
+    "EMType": 44,
+    "EntityIndex": 12,
+    "TargetLocation": {
+      "X": 29184,
+      "Y": -13312,
+      "Z": 58880,
+      "Room": 15
+    }
+  },
+
+  {
+    "Comments": "Add a trigger under the artefact so that picking it up will end the level.",
+    "EMType": 61,
+    "TriggerEntry": {
+      "Setup": {
+        "Value": 4
+      },
+      "TrigSetup": {
+        "Value": 15872
+      },
+      "TrigType": 4,
+      "TrigActionList": [
+        {
+          "TrigAction": 0,
+          "Parameter": 12
+        },
+        {
+          "TrigAction": 7
+        }
+      ]
+    },
+    "Locations": [
+      {
+        "X": 29184,
+        "Y": -13312,
+        "Z": 58880,
+        "Room": 15
+      }
+    ]
+  },
+
+  {
+    "Comments": "Make a ladder to reach the artefact.",
+    "EMType": 0,
+    "Location": {
+      "X": 34232,
+      "Y": -9984,
+      "Z": 58911,
+      "Room": 13
+    },
+    "IsNegativeX": true,
+    "TextureMap": {
+      "1490": {
+        "13": {
+          "Rectangles": [ 8, 9 ]
+        },
+        "14": {
+          "Rectangles": [ 51, 52 ]
+        }
+      }
+    }
+  },
+
+  {
+    "Comments": "Rotate the ladder faces so they look consistent.",
+    "EMType": 23,
+    "Rotations": [
+      {
+        "RoomNumber": 13,
+        "FaceType": 0,
+        "FaceIndices": [ 8, 9 ],
+        "VertexRemap": {
+          "0": 1,
+          "1": 2,
+          "2": 3,
+          "3": 0
+        }
+      },
+      {
+        "RoomNumber": 14,
+        "FaceType": 0,
+        "FaceIndices": [ 51, 52 ],
+        "VertexRemap": {
+          "0": 1,
+          "1": 2,
+          "2": 3,
+          "3": 0
+        }
+      }
+    ]
+  }
+]

--- a/TRRandomizerCore/Resources/TR3/BossMapping/TONYBOSS.TR2-BossMapping.json
+++ b/TRRandomizerCore/Resources/TR3/BossMapping/TONYBOSS.TR2-BossMapping.json
@@ -1,0 +1,32 @@
+[
+  {
+    "Comments": "Add a trigger under Tony so that picking up the stone will end the level.",
+    "EMType": 61,
+    "TriggerEntry": {
+      "Setup": {
+        "Value": 4
+      },
+      "TrigSetup": {
+        "Value": 15872
+      },
+      "TrigType": 4,
+      "TrigActionList": [
+        {
+          "TrigAction": 0,
+          "Parameter": 27
+        },
+        {
+          "TrigAction": 7
+        }
+      ]
+    },
+    "Locations": [
+      {
+        "X": 51437,
+        "Y": -256,
+        "Z": 52626,
+        "Room": 0
+      }
+    ]
+  }
+]

--- a/TRRandomizerCore/Resources/TR3/BossMapping/TRIBOSS.TR2-BossMapping.json
+++ b/TRRandomizerCore/Resources/TR3/BossMapping/TRIBOSS.TR2-BossMapping.json
@@ -1,0 +1,45 @@
+[
+  {
+    "Comments": "Get rid of the music trigger under Puna.",
+    "EMType": 62,
+    "Locations": [
+      {
+        "X": 65024,
+        "Y": -6144,
+        "Z": 57856,
+        "Room": 29
+      }
+    ]
+  },
+
+  {
+    "Comments": "Add a trigger under Puna so that picking up the stone will end the level.",
+    "EMType": 61,
+    "TriggerEntry": {
+      "Setup": {
+        "Value": 4
+      },
+      "TrigSetup": {
+        "Value": 15872
+      },
+      "TrigType": 4,
+      "TrigActionList": [
+        {
+          "TrigAction": 0,
+          "Parameter": 62
+        },
+        {
+          "TrigAction": 7
+        }
+      ]
+    },
+    "Locations": [
+      {
+        "X": 65024,
+        "Y": -6144,
+        "Z": 57856,
+        "Room": 29
+      }
+    ]
+  }
+]

--- a/TRRandomizerCore/TRRandomizerType.cs
+++ b/TRRandomizerCore/TRRandomizerType.cs
@@ -23,6 +23,7 @@
 
         // Individual settings
         DisableDemos = 100,
-        OutfitDagger
+        OutfitDagger,
+        SFX
     }
 }

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -1217,6 +1217,8 @@ namespace TRRandomizerView.Model
             // Called after the version type has been identified, so allows for customising
             // individual settings based on what's available.
             _removeRobeDagger.IsAvailable = IsOutfitDaggerSupported;
+
+            _changeWeaponSFX.IsAvailable = _changeCrashSFX.IsAvailable = _changeEnemySFX.IsAvailable = _linkCreatureSFX.IsAvailable = IsSFXSupported;
         }
 
         public void Load(TRRandomizerController controller)
@@ -1573,6 +1575,7 @@ namespace TRRandomizerView.Model
         public bool IsTextureTypeSupported => IsRandomizationSupported(TRRandomizerType.Texture);
         public bool IsStartPositionTypeSupported => IsRandomizationSupported(TRRandomizerType.StartPosition);
         public bool IsAudioTypeSupported => IsRandomizationSupported(TRRandomizerType.Audio);
+        public bool IsSFXSupported => IsRandomizationSupported(TRRandomizerType.SFX);
         public bool IsOutfitTypeSupported => IsRandomizationSupported(TRRandomizerType.Outfit);
         public bool IsOutfitDaggerSupported => IsRandomizationSupported(TRRandomizerType.OutfitDagger);
         public bool IsTextTypeSupported => IsRandomizationSupported(TRRandomizerType.Text);


### PR DESCRIPTION
## #219 Boss Levels and Exposure Meter
- Modifications will now take place based on level sequencing to cover issues with artefact pickups. If a boss level falls on Meteorite Cavern's sequence, triggers will be added under the artefacts to end the level. City is slightly different because Sophia moves around, so the pickup is moved in this instance and a path added to reach it. All changes are done using environment modifications so the JSON can be freely edited.
- If Meteorite Cavern is not in its original sequence, Willard is replaced with other enemies because the only way to kill him is by picking up the stones. The stones however have to be changed to keys, otherwise picking them up ends the level immediately. Even though Willie has gone, the "stones" still need to be collected to open the door near the end.
- Added logic to import the UPV into levels that have the exposure meter i.e. if they fall on Antarctica or RX-Tech sequence.

## TR3 SFX
The UI options for SFX have been hidden until this is properly implemented.

## #228 Barkhang Locations
Closes #228 by moving the three locations below the lanterns in room 70 to room 69 instead.