### PR TITLE
TR3 Mirroring

### DIFF
--- a/TREnvironmentEditor/Model/EMType.cs
+++ b/TREnvironmentEditor/Model/EMType.cs
@@ -60,6 +60,7 @@
 
         // Models
         ImportModel = 141,
+        MirrorModel = 142,
 
         // NOOP/Placeholder
         NOOP = 1000

--- a/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorModelFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorModelFunction.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using TRLevelReader.Helpers;
+using TRLevelReader.Model;
+using TRLevelReader.Model.Enums;
+using TRModelTransporter.Model.Textures;
+
+namespace TREnvironmentEditor.Model.Types
+{
+    public class EMMirrorModelFunction : BaseEMFunction
+    {
+        public uint[] ModelIDs { get; set; }
+
+        public override void ApplyToLevel(TR2Level level)
+        {
+            List<TRMesh> meshes = new List<TRMesh>();
+            foreach (uint modelID in ModelIDs)
+            {
+                TRMesh[] modelMeshes = TRMeshUtilities.GetModelMeshes(level, (TR2Entities)modelID);
+                if (modelMeshes == null || modelMeshes.Length > 1)
+                {
+                    throw new NotSupportedException("Only models with single meshes can be mirrored.");
+                }
+
+                meshes.Add(modelMeshes[0]);
+            }
+
+            MirrorObjectTextures(MirrorMeshes(meshes), level.ObjectTextures);
+        }
+
+        public override void ApplyToLevel(TR3Level level)
+        {
+            List<TRMesh> meshes = new List<TRMesh>();
+            foreach (uint modelID in ModelIDs)
+            {
+                TRMesh[] modelMeshes = TRMeshUtilities.GetModelMeshes(level, (TR3Entities)modelID);
+                if (modelMeshes == null || modelMeshes.Length > 1)
+                {
+                    throw new NotSupportedException("Only models with single meshes can be mirrored.");
+                }
+
+                meshes.Add(modelMeshes[0]);
+            }
+
+            MirrorObjectTextures(MirrorMeshes(meshes), level.ObjectTextures);
+        }
+
+        private ISet<ushort> MirrorMeshes(List<TRMesh> meshes)
+        {
+            ISet<ushort> textureReferences = new HashSet<ushort>();
+
+            foreach (TRMesh mesh in meshes)
+            {
+                foreach (TRVertex vert in mesh.Vertices)
+                {
+                    vert.X *= -1;
+                }
+
+                if (mesh.Normals != null)
+                {
+                    foreach (TRVertex norm in mesh.Normals)
+                    {
+                        norm.X *= -1;
+                    }
+                }
+
+                foreach (TRFace4 f in mesh.TexturedRectangles)
+                {
+                    Swap(f.Vertices, 0, 3);
+                    Swap(f.Vertices, 1, 2);
+                    textureReferences.Add((ushort)(f.Texture & 0x0fff));
+                }
+
+                foreach (TRFace4 f in mesh.ColouredRectangles)
+                {
+                    Swap(f.Vertices, 0, 3);
+                    Swap(f.Vertices, 1, 2);
+                }
+
+                foreach (TRFace3 f in mesh.TexturedTriangles)
+                {
+                    Swap(f.Vertices, 0, 2);
+                    textureReferences.Add((ushort)(f.Texture & 0x0fff));
+                }
+
+                foreach (TRFace3 f in mesh.ColouredTriangles)
+                {
+                    Swap(f.Vertices, 0, 2);
+                }
+            }
+
+            return textureReferences;
+        }
+
+        private void MirrorObjectTextures(ISet<ushort> textureReferences, TRObjectTexture[] objectTextures)
+        {
+            foreach (ushort textureRef in textureReferences)
+            {
+                IndexedTRObjectTexture texture = new IndexedTRObjectTexture
+                {
+                    Texture = objectTextures[textureRef]
+                };
+
+                if (texture.IsTriangle)
+                {
+                    Swap(texture.Texture.Vertices, 0, 2);
+                }
+                else
+                {
+                    Swap(texture.Texture.Vertices, 0, 3);
+                    Swap(texture.Texture.Vertices, 1, 2);
+                }
+            }
+        }
+
+        private static void Swap<T>(T[] arr, int pos1, int pos2)
+        {
+            T temp = arr[pos1];
+            arr[pos1] = arr[pos2];
+            arr[pos2] = temp;
+        }
+    }
+}

--- a/TREnvironmentEditor/Model/Types/Rooms/EMCopyRoomFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Rooms/EMCopyRoomFunction.cs
@@ -269,7 +269,7 @@ namespace TREnvironmentEditor.Model.Types
                             case FDFunctions.CeilingTriangulationNE_Solid:
                             case FDFunctions.FloorTriangulationNWSE_SW:
                             case FDFunctions.FloorTriangulationNWSE_NE:
-                            case FDFunctions.FloorTriangulationNESW_SW:
+                            case FDFunctions.FloorTriangulationNESW_SE:
                             case FDFunctions.FloorTriangulationNESW_NW:
                             case FDFunctions.CeilingTriangulationNW_SW:
                             case FDFunctions.CeilingTriangulationNW_NE:

--- a/TREnvironmentEditor/Parsing/EMConverter.cs
+++ b/TREnvironmentEditor/Parsing/EMConverter.cs
@@ -137,8 +137,11 @@ namespace TREnvironmentEditor.Parsing
                 case EMType.CopyVertexAttributes:
                     return JsonConvert.DeserializeObject<EMCopyVertexAttributesFunction>(jo.ToString(), _resolver);
 
+                // Models
                 case EMType.ImportModel:
                     return JsonConvert.DeserializeObject<EMImportModelFunction>(jo.ToString(), _resolver);
+                case EMType.MirrorModel:
+                    return JsonConvert.DeserializeObject<EMMirrorModelFunction>(jo.ToString(), _resolver);
 
                 // NOOP
                 case EMType.NOOP:

--- a/TRFDControl/FDControl.cs
+++ b/TRFDControl/FDControl.cs
@@ -252,7 +252,7 @@ namespace TRFDControl
                     case FDFunctions.CeilingTriangulationNE_Solid:
                     case FDFunctions.FloorTriangulationNWSE_SW:
                     case FDFunctions.FloorTriangulationNWSE_NE:
-                    case FDFunctions.FloorTriangulationNESW_SW:
+                    case FDFunctions.FloorTriangulationNESW_SE:
                     case FDFunctions.FloorTriangulationNESW_NW:
                     case FDFunctions.CeilingTriangulationNW_SW:
                     case FDFunctions.CeilingTriangulationNW_NE:

--- a/TRFDControl/FDEntryTypes/TR3TriangulationEntry.cs
+++ b/TRFDControl/FDEntryTypes/TR3TriangulationEntry.cs
@@ -17,7 +17,7 @@ namespace TRFDControl.FDEntryTypes
                 FDFunctions function = (FDFunctions)Setup.Function;
                 return function == FDFunctions.FloorTriangulationNESW_NW
                     || function == FDFunctions.FloorTriangulationNESW_Solid
-                    || function == FDFunctions.FloorTriangulationNESW_SW
+                    || function == FDFunctions.FloorTriangulationNESW_SE
                     || function == FDFunctions.FloorTriangulationNWSE_NE
                     || function == FDFunctions.FloorTriangulationNWSE_Solid
                     || function == FDFunctions.FloorTriangulationNWSE_SW;
@@ -30,7 +30,7 @@ namespace TRFDControl.FDEntryTypes
             {
                 FDFunctions function = (FDFunctions)Setup.Function;
                 return function == FDFunctions.FloorTriangulationNESW_NW
-                    || function == FDFunctions.FloorTriangulationNESW_SW
+                    || function == FDFunctions.FloorTriangulationNESW_SE
                     || function == FDFunctions.FloorTriangulationNWSE_NE
                     || function == FDFunctions.FloorTriangulationNWSE_SW;
             }

--- a/TRFDControl/FDFunctions.cs
+++ b/TRFDControl/FDFunctions.cs
@@ -20,7 +20,7 @@ namespace TRFDControl
         CeilingTriangulationNE_Solid = 0x0A,
         FloorTriangulationNWSE_SW = 0x0B,
         FloorTriangulationNWSE_NE = 0x0C,
-        FloorTriangulationNESW_SW = 0x0D,
+        FloorTriangulationNESW_SE = 0x0D, // TRosetta names this _SW but should be SE
         FloorTriangulationNESW_NW = 0x0E,
         CeilingTriangulationNW_SW = 0x0F,
         CeilingTriangulationNW_NE = 0x10,

--- a/TRFDControl/FDSetup.cs
+++ b/TRFDControl/FDSetup.cs
@@ -23,6 +23,11 @@ namespace TRFDControl
             {
                 return (byte)(Value & 0x001F);
             }
+            set
+            {
+                Value = (ushort)(Value & ~(Value & 0x001F));
+                Value |= value;
+            }
         }
 
         public byte ExtendedFunction
@@ -78,7 +83,12 @@ namespace TRFDControl
         {
             get
             {
-                return (sbyte)(Value & 0x03E0);
+                return (sbyte)((Value & 0x03E0) >> 5);
+            }
+            set
+            {
+                Value = (ushort)(Value & ~(Value & 0x03E0));
+                Value |= (ushort)(value << 5);
             }
         }
 
@@ -86,7 +96,12 @@ namespace TRFDControl
         {
             get
             {
-                return (sbyte)(Value & 0x7C00);
+                return (sbyte)((Value & 0x7C00) >> 10);
+            }
+            set
+            {
+                Value = (ushort)(Value & ~(Value & 0x7C00));
+                Value |= (ushort)(value << 10);
             }
         }
         #endregion

--- a/TRFDControl/FDTriangulationData.cs
+++ b/TRFDControl/FDTriangulationData.cs
@@ -16,6 +16,11 @@ namespace TRFDControl
             {
                 return (byte)(Value & 0x000F);
             }
+            set
+            {
+                Value = (ushort)(Value & ~(Value & 0x000F));
+                Value |= value;
+            }
         }
 
         public byte C00
@@ -23,6 +28,11 @@ namespace TRFDControl
             get
             {
                 return (byte)((Value & 0x00F0) >> 4);
+            }
+            set
+            {
+                Value = (ushort)(Value & ~(Value & 0x00F0));
+                Value |= (ushort)(value << 4);
             }
         }
 
@@ -32,6 +42,11 @@ namespace TRFDControl
             {
                 return (byte)((Value & 0x0F00) >> 8);
             }
+            set
+            {
+                Value = (ushort)(Value & ~(Value & 0x0F00));
+                Value |= (ushort)(value << 8);
+            }
         }
 
         public byte C11
@@ -39,6 +54,11 @@ namespace TRFDControl
             get
             {
                 return (byte)((Value & 0xF000) >> 12);
+            }
+            set
+            {
+                Value = (ushort)(Value & ~(Value & 0xF000));
+                Value |= (ushort)(value << 12);
             }
         }
     }

--- a/TRFDControl/Utilities/FDUtilities.cs
+++ b/TRFDControl/Utilities/FDUtilities.cs
@@ -364,7 +364,7 @@ namespace TRFDControl.Utilities
                 {
                     return -1;
                 }
-                else if (func == FDFunctions.FloorTriangulationNESW_SW && dx <= dz)
+                else if (func == FDFunctions.FloorTriangulationNESW_SE && dx <= dz)
                 {
                     return -1;
                 }

--- a/TRLevelReader/Helpers/TR3EntityUtilities.cs
+++ b/TRLevelReader/Helpers/TR3EntityUtilities.cs
@@ -618,5 +618,20 @@ namespace TRLevelReader.Helpers
                 || IsLightType(entity)
                 || entity == TR3Entities.Lara;
         }
+
+        public static List<TR3Entities> DoorTypes()
+        {
+            return new List<TR3Entities>
+            {
+                TR3Entities.Door1, TR3Entities.Door2, TR3Entities.Door3,
+                TR3Entities.Door4, TR3Entities.Door5, TR3Entities.Door6,
+                TR3Entities.Door7, TR3Entities.Door8
+            };
+        }
+
+        public static bool IsDoorType(TR3Entities entity)
+        {
+            return DoorTypes().Contains(entity);
+        }
     }
 }

--- a/TRLevelReader/Model/TR3/TR3Room.cs
+++ b/TRLevelReader/Model/TR3/TR3Room.cs
@@ -188,8 +188,11 @@ namespace TRLevelReader.Model
                     vert.Colour = (ushort)((Blend(curRed, newRed) << 10) | (Blend(curGreen, newGreen) << 5) | (Blend(curBlue, newBlue)));
                 }
 
-                vert.UseCaustics = enableCaustics;
-                vert.UseWaveMovement = enableWave;
+                // #296 Retain original caustics and waves for water/swamp rooms
+                if (!vert.UseCaustics)
+                    vert.UseCaustics = enableCaustics;
+                if (!vert.UseWaveMovement)
+                    vert.UseWaveMovement = enableWave;
             }
         }
 

--- a/TRRandomizerCore/Editors/TR3RandoEditor.cs
+++ b/TRRandomizerCore/Editors/TR3RandoEditor.cs
@@ -152,6 +152,16 @@ namespace TRRandomizerCore.Editors
                     }.Run();
                 }
 
+                TR3EnvironmentRandomizer environmentRandomizer = new TR3EnvironmentRandomizer
+                {
+                    ScriptEditor = tr23ScriptEditor,
+                    Levels = levels,
+                    BasePath = wipDirectory,
+                    SaveMonitor = monitor,
+                    Settings = Settings,
+                    TextureMonitor = textureMonitor
+                };
+
                 if (!monitor.IsCancelled && Settings.RandomizeSecrets)
                 {
                     monitor.FireSaveStateBeginning(TRSaveCategory.Custom, "Randomizing secrets");
@@ -163,7 +173,8 @@ namespace TRRandomizerCore.Editors
                         SaveMonitor = monitor,
                         Settings = Settings,
                         TextureMonitor = textureMonitor,
-                        ItemFactory = itemFactory
+                        ItemFactory = itemFactory,
+                        MirrorLevels = environmentRandomizer.AllocateMirroredLevels(Settings.EnvironmentSeed)
                     }.Randomize(Settings.SecretSeed);
                 }
 
@@ -214,15 +225,7 @@ namespace TRRandomizerCore.Editors
                 if (!monitor.IsCancelled)
                 {
                     monitor.FireSaveStateBeginning(TRSaveCategory.Custom, Settings.RandomizeEnvironment ? "Randomizing environment" : "Applying default environment packs");
-                    new TR3EnvironmentRandomizer
-                    {
-                        ScriptEditor = tr23ScriptEditor,
-                        Levels = levels,
-                        BasePath = wipDirectory,
-                        SaveMonitor = monitor,
-                        Settings = Settings,
-                        TextureMonitor = textureMonitor
-                    }.Randomize(Settings.EnvironmentSeed);
+                    environmentRandomizer.Randomize(Settings.EnvironmentSeed);
                 }
 
                 if (!monitor.IsCancelled && Settings.RandomizeAudio)

--- a/TRRandomizerCore/Editors/TR3RandoEditor.cs
+++ b/TRRandomizerCore/Editors/TR3RandoEditor.cs
@@ -213,7 +213,7 @@ namespace TRRandomizerCore.Editors
 
                 if (!monitor.IsCancelled)
                 {
-                    monitor.FireSaveStateBeginning(TRSaveCategory.Custom, /*Settings.RandomizeEnvironment ? "Randomizing environment" : */"Applying default environment packs");
+                    monitor.FireSaveStateBeginning(TRSaveCategory.Custom, Settings.RandomizeEnvironment ? "Randomizing environment" : "Applying default environment packs");
                     new TR3EnvironmentRandomizer
                     {
                         ScriptEditor = tr23ScriptEditor,

--- a/TRRandomizerCore/Helpers/LevelState.cs
+++ b/TRRandomizerCore/Helpers/LevelState.cs
@@ -1,0 +1,9 @@
+﻿namespace TRRandomizerCore.Helpers
+{
+    public enum LevelState
+    {
+        Any,
+        Mirrored,
+        NotMirrored
+    }
+}

--- a/TRRandomizerCore/Helpers/Location.cs
+++ b/TRRandomizerCore/Helpers/Location.cs
@@ -31,6 +31,8 @@ namespace TRRandomizerCore.Helpers
 
         public bool InvalidatesRoom { get; set; }
 
+        public LevelState LevelState {get; set;}
+
         public Location()
         {
             X = 0;
@@ -47,6 +49,7 @@ namespace TRRandomizerCore.Helpers
             RequiresDamage = false;
             KeyItemGroupID = 0;
             InvalidatesRoom = false;
+            LevelState = LevelState.Any;
         }
 
         public Location(TRViewLocation loc)

--- a/TRRandomizerCore/Randomizers/TR3/TR3EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3EnvironmentRandomizer.cs
@@ -14,7 +14,7 @@ namespace TRRandomizerCore.Randomizers
 {
     public class TR3EnvironmentRandomizer : BaseTR3Randomizer
     {
-        internal bool EnforcedModeOnly => true;//!Settings.RandomizeEnvironment;
+        internal bool EnforcedModeOnly => !Settings.RandomizeEnvironment;
         internal TR3TextureMonitorBroker TextureMonitor { get; set; }
 
         private List<EMType> _disallowedTypes;
@@ -62,7 +62,17 @@ namespace TRRandomizerCore.Randomizers
 
         private void RandomizeEnvironment(TR3CombinedLevel level)
         {
-            EMEditorMapping mapping = EMEditorMapping.Get(GetResourcePath(@"TR3\Environment\" + level.Name + "-Environment.json"));
+            string json = @"TR3\Environment\" + level.Name + "-Environment.json";
+            if (IsJPVersion)
+            {
+                string jpJson = @"TR3\Environment\" + level.Name + "-JP-Environment.json";
+                if (ResourceExists(jpJson))
+                {
+                    json = jpJson;
+                }
+            }
+
+            EMEditorMapping mapping = EMEditorMapping.Get(GetResourcePath(json));
             if (mapping != null)
             {
                 ApplyMappingToLevel(level, mapping);

--- a/TRRandomizerCore/Randomizers/TR3/TR3EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3EnvironmentRandomizer.cs
@@ -20,9 +20,42 @@ namespace TRRandomizerCore.Randomizers
         private List<EMType> _disallowedTypes;
         private List<TR3ScriptedLevel> _levelsToMirror;
 
+        public List<TR3ScriptedLevel> AllocateMirroredLevels(int seed)
+        {
+            if (!Settings.RandomizeEnvironment)
+            {
+                return new List<TR3ScriptedLevel>();
+            }
+
+            // This will only allocate once
+            if (_generator == null)
+            {
+                _generator = new Random(seed);
+            }
+
+            if (_levelsToMirror == null)
+            {
+                TR3ScriptedLevel assaultCourse = Levels.Find(l => l.Is(TR3LevelNames.ASSAULT));
+                _levelsToMirror = Levels.RandomSelection(_generator, (int)Settings.MirroredLevelCount, exclusions: new HashSet<TR3ScriptedLevel>
+                {
+                    assaultCourse
+                });
+
+                if (Settings.MirrorAssaultCourse)
+                {
+                    _levelsToMirror.Add(assaultCourse);
+                }
+            }
+
+            return new List<TR3ScriptedLevel>(_levelsToMirror);
+        }
+
         public override void Randomize(int seed)
         {
-            _generator = new Random(seed);
+            if (_generator == null)
+            {
+                _generator = new Random(seed);
+            }
 
             _disallowedTypes = new List<EMType>();
             if (!Settings.RandomizeWaterLevels)
@@ -40,10 +73,7 @@ namespace TRRandomizerCore.Randomizers
                 _disallowedTypes.Add(EMType.Ladder);
             }
 
-            _levelsToMirror = Levels.RandomSelection(_generator, (int)Settings.MirroredLevelCount, exclusions: new HashSet<TR3ScriptedLevel>
-            {
-                Levels.Find(l => l.Is(TR3LevelNames.ASSAULT))
-            });
+            AllocateMirroredLevels(seed);
 
             foreach (TR3ScriptedLevel lvl in Levels)
             {
@@ -78,7 +108,7 @@ namespace TRRandomizerCore.Randomizers
                 ApplyMappingToLevel(level, mapping);
             }
 
-            if (!EnforcedModeOnly && (_levelsToMirror.Contains(level.Script) || (level.IsAssault && Settings.MirrorAssaultCourse)))
+            if (!EnforcedModeOnly && _levelsToMirror.Contains(level.Script))
             {
                 MirrorLevel(level, mapping);
             }

--- a/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
@@ -50,6 +50,7 @@ namespace TRRandomizerCore.Randomizers
 
         internal TR3TextureMonitorBroker TextureMonitor { get; set; }
         public ItemFactory ItemFactory { get; set; }
+        public List<TR3ScriptedLevel> MirrorLevels { get; set; }
 
         public override void Randomize(int seed)
         {
@@ -338,6 +339,12 @@ namespace TRRandomizerCore.Randomizers
             {
                 if (_devRooms == null || _devRooms.Contains(location.Room))
                 {
+                    if (MirrorLevels.Contains(level.Script) && location.LevelState == LevelState.NotMirrored)
+                        continue;
+
+                    if (!MirrorLevels.Contains(level.Script) && location.LevelState == LevelState.Mirrored)
+                        continue;
+
                     secret.Location = location;
                     secret.EntityIndex = (ushort)ItemFactory.GetNextIndex(level.Name, entities, true);
                     secret.SecretIndex = (ushort)(secretIndex % countedSecrets); // Cycle through each secret number
@@ -403,7 +410,7 @@ namespace TRRandomizerCore.Randomizers
                 }
                 while
                 (
-                    !EvaluateProximity(location, usedLocations)     
+                    !EvaluateProximity(location, usedLocations, level)
                 );
 
                 _proxEvaluationCount = 0;
@@ -450,7 +457,7 @@ namespace TRRandomizerCore.Randomizers
             AddDamageControl(level, pickupTypes, damagingLocationUsed, glitchedDamagingLocationUsed);
         }
 
-        private bool EvaluateProximity(Location loc, List<Location> usedLocs)
+        private bool EvaluateProximity(Location loc, List<Location> usedLocs, TR3CombinedLevel level)
         {
             bool SafeToPlace = true;
             float proximity = 10000.0f;
@@ -459,6 +466,12 @@ namespace TRRandomizerCore.Randomizers
                 return false;
 
             if (loc.RequiresGlitch && !Settings.GlitchedSecrets)
+                return false;
+
+            if (MirrorLevels.Contains(level.Script) && loc.LevelState == LevelState.NotMirrored)
+                return false;
+
+            if (!MirrorLevels.Contains(level.Script) && loc.LevelState == LevelState.Mirrored)
                 return false;
 
             if (usedLocs.Count == 0 || usedLocs == null)

--- a/TRRandomizerCore/Resources/Shared/randomizer.json
+++ b/TRRandomizerCore/Resources/Shared/randomizer.json
@@ -1,0 +1,46 @@
+{
+  "fields": {
+    "Difficulty": {
+      "default": "Easy",
+      "display": "Difficulty",
+      "options": [ "Easy", "Medium", "Hard" ],
+      "type": "string"
+    },
+    "RequiresGlitch": {
+      "default": false,
+      "display": "Requires Glitch",
+      "type": "boolean"
+    },
+    "VehicleRequired": {
+      "default": false,
+      "display": "Vehicle Required",
+      "type": "boolean"
+    },
+    "Validated": {
+      "default": true,
+      "display": "Validated",
+      "type": "boolean"
+    },
+    "InvalidatesRoom": {
+      "default": false,
+      "display": "Invalidates Room",
+      "type": "boolean"
+    },
+    "RequiresDamage": {
+      "default": false,
+      "display": "Requires Damage",
+      "type": "boolean"
+    },
+    "KeyItemGroupID": {
+      "default": 0,
+      "display": "Key Item Group ID",
+      "type": "number"
+    },
+    "LevelState": {
+      "default": "Any",
+      "display": "Level State",
+      "options": [ "Any", "Mirrored", "NotMirrored" ],
+      "type": "string"
+    }
+  }
+}

--- a/TRRandomizerCore/Resources/TR3/Environment/ANTARC.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/ANTARC.TR2-Environment.json
@@ -106,5 +106,48 @@
         }
       ]
     }
+  ],
+
+  "Mirrored": [
+    {
+      "Comments": "The generators in this room are awkward so need rotating and shifting slightly.",
+      "EMType": 44,
+      "EntityIndex": 118,
+      "TargetLocation": {
+        "X": 33024,
+        "Y": -4864,
+        "Z": 76288,
+        "Room": 172,
+        "Angle": 16384
+      }
+    },
+    {
+      "EMType": 44,
+      "EntityIndex": 119,
+      "TargetLocation": {
+        "X": 32256,
+        "Y": -4864,
+        "Z": 74496,
+        "Room": 172,
+        "Angle": -32768
+      }
+    },
+    {
+      "Comments": "Mirror the Slot2Empty and Slot2Full models.",
+      "EMType": 142,
+      "ModelIDs": [ 214, 218 ]
+    },
+    {
+      "Comments": "Move door #36 so it's less awkward.",
+      "EMType": 44,
+      "EntityIndex": 36,
+      "TargetLocation": {
+        "X": 55808,
+        "Y": -4864,
+        "Z": 23040,
+        "Room": 131,
+        "Angle": 16384
+      }
+    }
   ]
 }

--- a/TRRandomizerCore/Resources/TR3/Environment/AREA51.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/AREA51.TR2-Environment.json
@@ -324,5 +324,14 @@
         }
       ]
     }
+  ],
+
+  "Mirrored": [
+    {
+      "Comments": "Make door #182 a split one so Lara can pass.",
+      "EMType": 45,
+      "EntityIndex": 182,
+      "NewEntityType": 137
+    }
   ]
 }

--- a/TRRandomizerCore/Resources/TR3/Environment/COMPOUND.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/COMPOUND.TR2-Environment.json
@@ -191,5 +191,14 @@
         }
       ]
     }
+  ],
+
+  "Mirrored": [
+    {
+      "Comments": "Make door #125 a vertical one as this corridor is awkward.",
+      "EMType": 45,
+      "EntityIndex": 125,
+      "NewEntityType": 136
+    }
   ]
 }

--- a/TRRandomizerCore/Resources/TR3/Environment/MINES.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/MINES.TR2-Environment.json
@@ -63,5 +63,20 @@
         }
       ]
     }
+  ],
+
+  "Mirrored": [
+    {
+      "Comments": "Move door #40 so the maze can be beaten",
+      "EMType": 44,
+      "EntityIndex": 40,
+      "TargetLocation": {
+        "X": 40448,
+        "Y": -512,
+        "Z": 27136,
+        "Room": 51,
+        "Angle": -32768
+      }
+    }
   ]
 }

--- a/TRRandomizerCore/Resources/TR3/Environment/NEVADA.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/NEVADA.TR2-Environment.json
@@ -1,0 +1,15 @@
+{
+  "Mirrored": [
+    {
+      "Comments": "Convert two of the planes to the other kind.",
+      "EMType": 45,
+      "EntityIndex": 8,
+      "NewEntityType": 351
+    },
+    {
+      "EMType": 45,
+      "EntityIndex": 113,
+      "NewEntityType": 351
+    }
+  ]
+}

--- a/TRRandomizerCore/Resources/TR3/Environment/ROOFS.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/ROOFS.TR2-Environment.json
@@ -1,0 +1,16 @@
+﻿{
+  "Mirrored": [
+    {
+      "Comments": "Move door #34 otherwise Lara can't pass.",
+      "EMType": 44,
+      "EntityIndex": 34,
+      "TargetLocation": {
+        "X": 48640,
+        "Y": -8448,
+        "Z": 36352,
+        "Room": 43,
+        "Angle": -32768
+      }
+    }
+  ]
+}

--- a/TRRandomizerCore/Resources/TR3/Environment/ROOFS.TR2-JP-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/ROOFS.TR2-JP-Environment.json
@@ -1,0 +1,16 @@
+﻿{
+  "Mirrored": [
+    {
+      "Comments": "Move door #35 otherwise Lara can't pass.",
+      "EMType": 44,
+      "EntityIndex": 35,
+      "TargetLocation": {
+        "X": 48640,
+        "Y": -8448,
+        "Z": 36352,
+        "Room": 43,
+        "Angle": -32768
+      }
+    }
+  ]
+}

--- a/TRRandomizerCore/Resources/TR3/Environment/SEWER.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/SEWER.TR2-Environment.json
@@ -240,5 +240,44 @@
         }
       ]
     }
+  ],
+
+  "Mirrored": [
+    {
+      "Comments": "Move slot #69 otherwise it's hidden.",
+      "EMType": 44,
+      "EntityIndex": 69,
+      "TargetLocation": {
+        "X": 34304,
+        "Y": -5888,
+        "Z": 85760,
+        "Room": 37,
+        "Angle": -16384
+      }
+    },
+    {
+      "Comments": "Move the Solomon room moon.",
+      "EMType": 44,
+      "EntityIndex": 10,
+      "TargetLocation": {
+        "X": 48640,
+        "Y": 896,
+        "Z": 22016,
+        "Room": 1,
+        "Angle": -32768
+      }
+    },
+    {
+      "Comments": "Move door #193 so it's less awkward.",
+      "EMType": 44,
+      "EntityIndex": 193,
+      "TargetLocation": {
+        "X": 45568,
+        "Y": 2560,
+        "Z": 36352,
+        "Room": 104,
+        "Angle": 0
+      }
+    }
   ]
 }

--- a/TRRandomizerCore/Resources/TR3/Environment/SHORE_.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/SHORE_.TR2-Environment.json
@@ -1,0 +1,82 @@
+﻿{
+  "Mirrored": [
+    {
+      "Comments": "Move the slots and doors leading to the village as it's an awkward corridor.",
+      "EMType": 41,
+      "EntityIndex": 134,
+      "Location": {
+        "X": 54784,
+        "Y": -2816,
+        "Z": 90624,
+        "Room": 134,
+        "Angle": -16384
+      }
+    },
+    {
+      "EMType": 41,
+      "EntityIndex": 131,
+      "Location": {
+        "X": 54784,
+        "Y": -2560,
+        "Z": 91648,
+        "Room": 133,
+        "Angle": 16384
+      }
+    },
+    {
+      "EMType": 41,
+      "EntityIndex": 132,
+      "Location": {
+        "X": 54784,
+        "Y": -2560,
+        "Z": 92672,
+        "Room": 133,
+        "Angle": 16384
+      }
+    },
+    {
+      "EMType": 44,
+      "EntityIndex": 133,
+      "TargetLocation": {
+        "X": 54784,
+        "Y": -2560,
+        "Z": 90624,
+        "Room": 134,
+        "Angle": -32768
+      }
+    },
+    {
+      "EMType": 44,
+      "EntityIndex": 129,
+      "TargetLocation": {
+        "X": 54784,
+        "Y": -2560,
+        "Z": 91648,
+        "Room": 134,
+        "Angle": -32768
+      }
+    },
+    {
+      "EMType": 44,
+      "EntityIndex": 130,
+      "TargetLocation": {
+        "X": 54784,
+        "Y": -2560,
+        "Z": 92672,
+        "Room": 133,
+        "Angle": -32768
+      }
+    },
+    {
+      "EMType": 44,
+      "EntityIndex": 135,
+      "TargetLocation": {
+        "X": 54784,
+        "Y": -2816,
+        "Z": 90624,
+        "Room": 134,
+        "Angle": 16384
+      }
+    }
+  ]
+}

--- a/TRRandomizerCore/Resources/TR3/Environment/STPAUL.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/STPAUL.TR2-Environment.json
@@ -1,0 +1,16 @@
+{
+  "Mirrored": [
+    {
+      "Comments": "Move door #36 so it's less awkward.",
+      "EMType": 44,
+      "EntityIndex": 11,
+      "TargetLocation": {
+        "X": 12800,
+        "Y": 1280,
+        "Z": 66048,
+        "Room": 17,
+        "Angle": 0
+      }
+    }
+  ]
+}

--- a/TRRandomizerCore/Resources/TR3/Environment/TOWER.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/TOWER.TR2-Environment.json
@@ -54,5 +54,20 @@
         }
       ]
     }
+  ],
+
+  "Mirrored": [
+    {
+      "Comments": "Move door #143 so Lara can pass.",
+      "EMType": 44,
+      "EntityIndex": 143,
+      "TargetLocation": {
+        "X": 39424,
+        "Y": -30976,
+        "Z": 37376,
+        "Room": 132,
+        "Angle": 16384
+      }
+    }
   ]
 }

--- a/TRRandomizerCore/Resources/TR3/Environment/TRIBOSS.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/TRIBOSS.TR2-Environment.json
@@ -1,0 +1,28 @@
+﻿{
+  "Mirrored": [
+    {
+      "Comments": "Move door #36 otherwise Lara can't pass.",
+      "EMType": 44,
+      "EntityIndex": 36,
+      "TargetLocation": {
+        "X": 73216,
+        "Y": -14592,
+        "Z": 51712,
+        "Room": 21,
+        "Angle": 0
+      }
+    },
+    {
+      "Comments": "Move door #42 otherwise it's awkward to pass.",
+      "EMType": 44,
+      "EntityIndex": 42,
+      "TargetLocation": {
+        "X": 76288,
+        "Y": -10240,
+        "Z": 48640,
+        "Room": 22,
+        "Angle": 16384
+      }
+    }
+  ]
+}

--- a/TRRandomizerCore/TRRandomizerController.cs
+++ b/TRRandomizerCore/TRRandomizerController.cs
@@ -27,7 +27,7 @@ namespace TRRandomizerCore
                 TRRandomizerType.LevelSequence, TRRandomizerType.Unarmed, TRRandomizerType.Ammoless, TRRandomizerType.Audio, TRRandomizerType.Outfit,
                 TRRandomizerType.Secret, TRRandomizerType.GlobeDisplay, TRRandomizerType.RewardRooms, TRRandomizerType.SFX, TRRandomizerType.Item, 
                 TRRandomizerType.NightMode, TRRandomizerType.SecretReward, TRRandomizerType.Text, TRRandomizerType.Enemy, TRRandomizerType.Texture,
-                TRRandomizerType.StartPosition, TRRandomizerType.VFX
+                TRRandomizerType.StartPosition, TRRandomizerType.VFX, TRRandomizerType.Environment
             }
         };
 

--- a/TRRandomizerCore/TRRandomizerCore.csproj
+++ b/TRRandomizerCore/TRRandomizerCore.csproj
@@ -40,5 +40,8 @@
     <None Update="Resources\Documentation\ORDER.md">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\Shared\randomizer.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/TRRandomizerCore/Utilities/LocationGenerator.cs
+++ b/TRRandomizerCore/Utilities/LocationGenerator.cs
@@ -494,7 +494,7 @@ namespace TRRandomizerCore.Utilities
                     break;
 
                 case FDFunctions.FloorTriangulationNESW_Solid:
-                case FDFunctions.FloorTriangulationNESW_SW:
+                case FDFunctions.FloorTriangulationNESW_SE:
                 case FDFunctions.FloorTriangulationNESW_NW:
                     triangle1 = new List<Vector3>
                     {
@@ -571,7 +571,7 @@ namespace TRRandomizerCore.Utilities
                         zOffset = zoff1;
                         bestMatch = new Vector4(triSum1.X, triSum1.Y, triSum1.Z, angle);
                     }
-                    else if (func != FDFunctions.FloorTriangulationNESW_SW)
+                    else if (func != FDFunctions.FloorTriangulationNESW_SE)
                     {
                         xOffset = xoff2;
                         zOffset = zoff2;

--- a/TRRandomizerView/Controls/EditorControl.xaml
+++ b/TRRandomizerView/Controls/EditorControl.xaml
@@ -365,7 +365,7 @@
             <ctrl:ManagedSeedAdvancedControl.AdvancedWindowToOpen>
                 <windows:AdvancedWindow Title="Randomize Environment (Advanced)"
                                         MainDescription="Customize the environmental randomization."
-                                        HasBoolItems="True"
+                                        HasBoolItems="{Binding Data.IsRewardRoomsTypeSupported, Source={StaticResource proxy}, Converter={StaticResource InverseBooleanConverter}}"
                                         HasMirroring="True"
                                         BoolItemsSource="{Binding Data.EnvironmentBoolItemControls, Source={StaticResource proxy}}"
                                         ControllerProxy="{Binding Data, Source={StaticResource proxy}}">

--- a/TextureExport/Types/FaceMapper.cs
+++ b/TextureExport/Types/FaceMapper.cs
@@ -249,7 +249,7 @@ namespace TextureExport.Types
 
         private static TexturedTileSegment GetFaceSegment(int textureIndex, IReadOnlyList<TexturedTile> tiles)
         {
-            List<int> indices = new List<int> { textureIndex };
+            List<int> indices = new List<int> { textureIndex & 0x0fff };
             foreach (TexturedTile tile in tiles)
             {
                 List<TexturedTileSegment> segments = tile.GetObjectTextureIndexSegments(indices);


### PR DESCRIPTION
## #241 Mirroring Implementation
FDControl updates for mirroring:
- Renamed `FDFunctions.FloorTriangulationNESW_SW` to `FDFunctions.FloorTriangulationNESW_SE` as this appears to be a typo in TRosettaStone (SE indicates right-angle of triangle portal).
- Added ability to set `Function`, `H1` and `H2` values in `FDSetup`.
- Added ability to set corner values of `FDTriangulationData`.

Main mirroring details:
- Main level mirroring implemented for TR3, including the minor environment changes needed for awkward doors and suchlike in each level. Note that Thames has two environment JSON files, with the extra one targeted at the Japanese version because of entity differences.
- Function added to mirror a model, but this is only possible for ones that have only one mesh and no animations (Slot2 in Antarctica for example).
- Move slot function implemented for TR3.
- Mirroring option made available in UI (no other environment options yet - these are temporarily hidden by checking if the reward room type is available to target TR3 only).

## #295 Mirrored Secret Filtering
Closes #295. Added a `LevelState` property to `Location` to allow secrets to be tied to mirrored or non-mirrored levels. The default is `Any`, which means that a location is universal. If mirroring is selected, the list of levels will be allocated prior to the secrets being placed so that the secret randomizer knows which locations it can use. The mirroring itself still takes place later, so this also means that mirrored-only secrets must be defined in normal world space.

Added a `randomizer.json` trview settings file to the shared resources for convenience so this can be edited alongside `Location` as necessary. This won't be included in the build.

## #296 Caustics/Waves
Closes #296. Adds checks in `TR3Room` to only modify caustics/waves if the vertex doesn't already have these set, so that normal water and swamp rooms retain the effects as standard.