### PR TITLE
TR2/3 Fixes

### DIFF
--- a/TRLevelReader/Model/TR2/Enums/TR2Entities.cs
+++ b/TRLevelReader/Model/TR2/Enums/TR2Entities.cs
@@ -291,6 +291,7 @@ namespace TRLevelReader.Model.Enums
         LaraMiscAnim_H_Xian,       // Death-by-Guard, inspecting dagger
         LaraMiscAnim_H_Wall,       // Death-by-Barney
         LaraMiscAnim_H_HSH,        // Inspecting dagger at home
+        LaraMiscAnim_H_Venice,     // Bartoli's detonator
 
         // Split Lara's outfits and weapon animations
         LaraSun = 3000,

--- a/TRModelTransporter/Data/TR2DefaultDataProvider.cs
+++ b/TRModelTransporter/Data/TR2DefaultDataProvider.cs
@@ -223,7 +223,7 @@ namespace TRModelTransporter.Data
 
             [TR2Entities.LaraMiscAnim_H] = new List<TR2Entities>
             {
-                TR2Entities.LaraMiscAnim_H_Wall, TR2Entities.LaraMiscAnim_H_Unwater, TR2Entities.LaraMiscAnim_H_Ice, TR2Entities.LaraMiscAnim_H_Xian, TR2Entities.LaraMiscAnim_H_HSH
+                TR2Entities.LaraMiscAnim_H_Wall, TR2Entities.LaraMiscAnim_H_Unwater, TR2Entities.LaraMiscAnim_H_Ice, TR2Entities.LaraMiscAnim_H_Xian, TR2Entities.LaraMiscAnim_H_HSH, TR2Entities.LaraMiscAnim_H_Venice
             },
 
             [TR2Entities.TigerOrSnowLeopard] = new List<TR2Entities>

--- a/TRRandomizerCore/Resources/TR3/Environment/AREA51.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/AREA51.TR2-Environment.json
@@ -332,6 +332,81 @@
       "EMType": 45,
       "EntityIndex": 182,
       "NewEntityType": 137
+    },
+
+    {
+      "Comments": "There are hard-coded shenanigans for the missile blast, meaning it won't work in mirrored. So make it a dramatic medi pack instead, and make the beams other pickups.",
+      "EMType": 45,
+      "EntityIndex": 70,
+      "NewEntityType": 177
+    },
+    {
+      "EMType": 45,
+      "EntityIndex": 72,
+      "NewEntityType": 178
+    },
+    {
+      "EMType": 45,
+      "EntityIndex": 77,
+      "NewEntityType": 169
+    },
+    {
+      "Comments": "Move the items to the floor.",
+      "EMType": 44,
+      "EntityIndex": 70,
+      "TargetLocation": {
+        "X": 44038,
+        "Y": 6400,
+        "Z": 64500,
+        "Room": 52,
+        "Angle": -32768
+      }
+    },
+    {
+      "EMType": 44,
+      "EntityIndex": 72,
+      "TargetLocation": {
+        "X": 55808,
+        "Y": 5632,
+        "Z": 65024,
+        "Room": 57,
+        "Angle": -16384
+      }
+    },
+    {
+      "EMType": 44,
+      "EntityIndex": 77,
+      "TargetLocation": {
+        "X": 55808,
+        "Y": 5632,
+        "Z": 62976,
+        "Room": 57,
+        "Angle": -16384
+      }
+    },
+    {
+      "Comments": "Get rid of the missile static meshes.",
+      "EMType": 25,
+      "ClearFromRooms": {
+        "17": [ 49, 51, 53 ],
+        "18": [ 147, 148 ],
+        "19": [ 49, 51, 53 ],
+        "20": [ 49, 51, 53 ]
+      }
+    },
+    {
+      "Comments": "Make the camera look at the medi pack.",
+      "EMType": 66,
+      "TrigAction": 6,
+      "NewParameter": 70,
+      "Locations": [
+        {
+          "X": 47616,
+          "Y": 5888,
+          "Z": 62976,
+          "Room": 109
+        }
+      ]
     }
   ]
 }

--- a/TRRandomizerCore/Utilities/TR2EnemyUtilities.cs
+++ b/TRRandomizerCore/Utilities/TR2EnemyUtilities.cs
@@ -493,6 +493,9 @@ namespace TRRandomizerCore.Utilities
             {
                 switch (lvlName)
                 {
+                    case TR2LevelNames.BARTOLI:
+                        priorities[TR2Entities.LaraMiscAnim_H] = TR2Entities.LaraMiscAnim_H_Venice;
+                        break;
                     case TR2LevelNames.RIG:
                     case TR2LevelNames.DA:
                     case TR2LevelNames.DORIA:


### PR DESCRIPTION
## #314 Enemy Mesh Swaps
Minor improvement to the logic for swapping enemy meshes with Lara's meshes, and also adds the chance of abominable Laras as enemies. Swapping Lara herself for anything else at the moment is not supported.

## #316 Bartoli Detonator Animation
Ensures that if an enemy that has a LaraMiscAnim dependency is imported into Bartoli's Hideout, that Lara's detonator animation remains in place, otherwise she just stands still when activating it. The other enemy death animations will just default to Lara's normal death animation.
Closes #316.

## #317 Mirrored Area51 Missile
When Area51 is mirrored, the missile blast kills Lara more or less immediately because there are some hard-coded calculations being done for the fire/blast sequence. If this level is mirrored, an alternative scenario now takes place to ensure the area is passable.
Closes #317.