### PR TITLE
Wheel Door Fixes

### DIFF
--- a/TREnvironmentEditor/Model/EMType.cs
+++ b/TREnvironmentEditor/Model/EMType.cs
@@ -30,6 +30,7 @@
         SwapSlot = 49,
         AdjustEntityPositions = 50,
         AddEntity = 51,
+        ConvertWheelDoor = 52,
 
         // Trigger types 61-80
         Trigger = 61,

--- a/TREnvironmentEditor/Model/Types/Entities/EMConvertWheelDoorFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Entities/EMConvertWheelDoorFunction.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using TREnvironmentEditor.Helpers;
+using TRLevelReader.Model;
+using TRLevelReader.Model.Enums;
+
+namespace TREnvironmentEditor.Model.Types
+{
+    public class EMConvertWheelDoorFunction : BaseEMFunction
+    {
+        public int WheelIndex { get; set; }
+        public int DoorIndex { get; set; }
+        public short NewSwitchType { get; set; }
+        public short NewDoorType { get; set; }
+        public EMLocation NewLocation { get; set; }
+
+        public override void ApplyToLevel(TR2Level level)
+        {
+            TR2Entity wheel = level.Entities[WheelIndex];
+            if (wheel.TypeID != (short)TR2Entities.WheelKnob)
+            {
+                // Something else has already converted this
+                return;
+            }
+
+            // Make it a switch type
+            new EMConvertEntityFunction
+            {
+                EntityIndex = WheelIndex,
+                NewEntityType = NewSwitchType
+            }.ApplyToLevel(level);
+
+            // Make the door normal and match its lighting to another
+            TR2Entity otherDoor = Array.Find(level.Entities, e => e.TypeID == NewDoorType);
+            new EMConvertEntityFunction
+            {
+                EntityIndex = DoorIndex,
+                NewEntityType = NewDoorType
+            }.ApplyToLevel(level);
+            if (otherDoor != null)
+            {
+                level.Entities[DoorIndex].Intensity1 = otherDoor.Intensity1;
+                level.Entities[DoorIndex].Intensity2 = otherDoor.Intensity2;
+            }
+
+            if (NewLocation == null)
+            {
+                // This indicates that we want to get rid of the wheel and make its current trigger a pad
+                new EMConvertTriggerFunction
+                {
+                    TrigType = TRFDControl.FDTrigType.Pad,
+                    Location = new EMLocation
+                    {
+                        X = wheel.X,
+                        Y = wheel.Y,
+                        Z = wheel.Z,
+                        Room = wheel.Room
+                    }
+                }.ApplyToLevel(level);
+            }
+            else
+            {
+                // Make sure the trigger has the switch ref
+                new EMConvertTriggerFunction
+                {
+                    SwitchOrKeyRef = (ushort)WheelIndex,
+                    Location = new EMLocation
+                    {
+                        X = wheel.X,
+                        Y = wheel.Y,
+                        Z = wheel.Z,
+                        Room = wheel.Room
+                    }
+                }.ApplyToLevel(level);
+
+                // Finally, move the switch
+                new EMMoveSlotFunction
+                {
+                    EntityIndex = WheelIndex,
+                    Location = NewLocation
+                }.ApplyToLevel(level);
+            }
+        }
+
+        public override void ApplyToLevel(TR3Level level)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/TREnvironmentEditor/Parsing/EMConverter.cs
+++ b/TREnvironmentEditor/Parsing/EMConverter.cs
@@ -90,6 +90,8 @@ namespace TREnvironmentEditor.Parsing
                     return JsonConvert.DeserializeObject<EMAdjustEntityPositionFunction>(jo.ToString(), _resolver);
                 case EMType.AddEntity:
                     return JsonConvert.DeserializeObject<EMAddEntityFunction>(jo.ToString(), _resolver);
+                case EMType.ConvertWheelDoor:
+                    return JsonConvert.DeserializeObject<EMConvertWheelDoorFunction>(jo.ToString(), _resolver);
 
                 // Trigger types
                 case EMType.Trigger:

--- a/TRRandomizerCore/Randomizers/TR2/TR2EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2EnemyRandomizer.cs
@@ -432,7 +432,7 @@ namespace TRRandomizerCore.Randomizers
                 foreach (TR2ScriptedLevel level in Levels)
                 {
                     IEnumerable<TR2Entities> restrictedRoomEnemies = TR2EnemyUtilities.GetRestrictedEnemyRooms(level.LevelFileBaseName.ToUpper(), RandoDifficulty.Default).Keys;
-                    if (includedEnemies.All(e => restrictedRoomEnemies.Contains(e)))
+                    if (includedEnemies.All(e => restrictedRoomEnemies.Contains(e) || _gameEnemyTracker.ContainsKey(e)))
                     {
                         return RandoDifficulty.NoRestrictions;
                     }

--- a/TRRandomizerCore/Resources/TR2/Environment/KEEL.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/KEEL.TR2-Environment.json
@@ -1,6 +1,76 @@
 {
   "All": [],
 
+  "ConditionalAll": [
+    {
+      "Condition": {
+        "Comments": "If Marco is present, move him a little and convert wheel doors into regular ones.",
+        "ConditionType": 0,
+        "EntityIndex": 92,
+        "EntityType": 40
+      },
+      "OnTrue": [
+        {
+          "EMType": 44,
+          "EntityIndex": 92,
+          "TargetLocation": {
+            "X": 73984,
+            "Y": 5120,
+            "Z": 68352,
+            "Room": 55,
+            "Angle": -16384
+          }
+        },
+
+        {
+          "EMType": 52,
+          "WheelIndex": 39,
+          "DoorIndex": 38,
+          "NewSwitchType": 93,
+          "NewDoorType": 111,
+          "NewLocation": {
+            "X": 41472,
+            "Y": 3072,
+            "Z": 35328,
+            "Room": 35,
+            "Angle": 0
+          }
+        },
+
+        {
+          "EMType": 52,
+          "WheelIndex": 134,
+          "DoorIndex": 133,
+          "NewSwitchType": 93,
+          "NewDoorType": 111,
+          "NewLocation": {
+            "X": 55808,
+            "Y": 8960,
+            "Z": 85504,
+            "Room": 73,
+            "Angle": -32768
+          }
+        },
+
+        {
+          "Comments": "Convert those in room 58 to pad triggers because we can't tell where the keyhole here may be, so we don't want to clash with that.",
+          "EMType": 52,
+          "WheelIndex": 106,
+          "DoorIndex": 103,
+          "NewSwitchType": 145,
+          "NewDoorType": 111
+        },
+        {
+          "EMType": 52,
+          "WheelIndex": 107,
+          "DoorIndex": 100,
+          "NewSwitchType": 149,
+          "NewDoorType": 111
+        }
+      ]
+    }
+  ],
+
   "NonPurist": [
     {
       "Comments": "Make ladders for the first big drop.",

--- a/TRRandomizerCore/Resources/TR2/Environment/PLATFORM.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/PLATFORM.TR2-Environment.json
@@ -346,6 +346,36 @@
               }
             ]
           }
+        },
+
+        {
+          "Comments": "Convert wheel doors into regular ones as Lara's animation will have been overwritten.",
+          "EMType": 52,
+          "WheelIndex": 16,
+          "DoorIndex": 12,
+          "NewSwitchType": 93,
+          "NewDoorType": 106,
+          "NewLocation": {
+            "X": 46592,
+            "Y": -5120,
+            "Z": 70144,
+            "Room": 13,
+            "Angle": -32768
+          }
+        },
+        {
+          "EMType": 52,
+          "WheelIndex": 26,
+          "DoorIndex": 24,
+          "NewSwitchType": 93,
+          "NewDoorType": 106,
+          "NewLocation": {
+            "X": 52736,
+            "Y": -5120,
+            "Z": 78336,
+            "Room": 16,
+            "Angle": 16384
+          }
         }
       ]
     }

--- a/TRRandomizerCore/Resources/TR2/Environment/RIG.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/RIG.TR2-Environment.json
@@ -241,27 +241,15 @@
             "Angle": 0
           }
         },
+
         {
           "Comments": "Convert wheel doors into regular ones as Lara's animation will have been overwritten.",
-          "EMType": 45,
-          "EntityIndex": 28,
-          "NewEntityType": 103
-        },
-        {
-          "EMType": 45,
-          "EntityIndex": 26,
-          "NewEntityType": 106
-        },
-        {
-          "EMType": 48,
-          "EntityIndex": 26,
-          "Intensity1": 5120,
-          "Intensity2": 4096
-        },
-        {
-          "EMType": 44,
-          "EntityIndex": 28,
-          "TargetLocation": {
+          "EMType": 52,
+          "WheelIndex": 28,
+          "DoorIndex": 26,
+          "NewSwitchType": 103,
+          "NewDoorType": 106,
+          "NewLocation": {
             "X": 31232,
             "Y": -4096,
             "Z": 66048,
@@ -270,65 +258,17 @@
           }
         },
         {
-          "EMType": 69,
-          "SwitchOrKeyRef": 28,
-          "Location": {
-            "X": 31232,
-            "Y": -4096,
-            "Z": 66048,
-            "Room": 17
-          }
-        },
-        {
-          "EMType": 45,
-          "EntityIndex": 73,
-          "NewEntityType": 103
-        },
-        {
-          "EMType": 45,
-          "EntityIndex": 74,
-          "NewEntityType": 106
-        },
-        {
-          "EMType": 48,
-          "EntityIndex": 74,
-          "Intensity1": 5120,
-          "Intensity2": 4096
-        },
-        {
-          "EMType": 44,
-          "EntityIndex": 73,
-          "TargetLocation": {
+          "EMType": 52,
+          "WheelIndex": 73,
+          "DoorIndex": 74,
+          "NewSwitchType": 103,
+          "NewDoorType": 106,
+          "NewLocation": {
             "X": 33280,
             "Y": -4096,
             "Z": 59904,
             "Room": 43,
             "Angle": -16384
-          }
-        },
-        {
-          "EMType": 69,
-          "SwitchOrKeyRef": 73,
-          "Location": {
-            "X": 33280,
-            "Y": -4096,
-            "Z": 60928,
-            "Room": 43
-          }
-        },
-        {
-          "EMType": 67,
-          "BaseLocation": {
-            "X": 33280,
-            "Y": -4096,
-            "Z": 60928,
-            "Room": 43
-          },
-          "NewLocation": {
-            "X": 33280,
-            "Y": -4096,
-            "Z": 59904,
-            "Room": 43
           }
         }
       ]

--- a/TRRandomizerCore/Resources/TR2/Environment/RIG.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/RIG.TR2-Environment.json
@@ -216,34 +216,12 @@
   "ConditionalAll": [
     {
       "Condition": {
-        "Comments": "If Marco has been added and the plane area has been drained, move him there (he'll either be entity 8 or 9).",
-        "ConditionType": 0,
-        "EntityIndex": 8,
-        "EntityType": 40,
-        "And": [
-          {
-            "ConditionType": 21,
-            "RoomIndex": 88,
-            "Negate": true
-          }
-        ]
+        "Comments": "If the Marco model is present, we have to convert wheel doors because LaraMiscAnim will have been overwritten.",
+        "ConditionType": 41,
+        "ModelID": 40
       },
       "OnTrue": [
         {
-          "Comments": "Move Marco.",
-          "EMType": 44,
-          "EntityIndex": 8,
-          "TargetLocation": {
-            "X": 37854,
-            "Y": 2048,
-            "Z": 81803,
-            "Room": 88,
-            "Angle": 0
-          }
-        },
-
-        {
-          "Comments": "Convert wheel doors into regular ones as Lara's animation will have been overwritten.",
           "EMType": 52,
           "WheelIndex": 28,
           "DoorIndex": 26,
@@ -273,6 +251,36 @@
         }
       ]
     },
+
+    {
+      "Condition": {
+        "Comments": "If Marco has been added and the plane area has been drained, move him there (he'll either be entity 8 or 9).",
+        "ConditionType": 0,
+        "EntityIndex": 8,
+        "EntityType": 40,
+        "And": [
+          {
+            "ConditionType": 21,
+            "RoomIndex": 88,
+            "Negate": true
+          }
+        ]
+      },
+      "OnTrue": [
+        {
+          "Comments": "Move Marco.",
+          "EMType": 44,
+          "EntityIndex": 8,
+          "TargetLocation": {
+            "X": 37854,
+            "Y": 2048,
+            "Z": 81803,
+            "Room": 88,
+            "Angle": 0
+          }
+        }
+      ]
+    },
     {
       "Condition": {
         "ConditionType": 0,
@@ -296,96 +304,6 @@
             "Z": 81803,
             "Room": 88,
             "Angle": 0
-          }
-        },
-        {
-          "Comments": "Convert wheel doors into regular ones as Lara's animation will have been overwritten.",
-          "EMType": 45,
-          "EntityIndex": 28,
-          "NewEntityType": 103
-        },
-        {
-          "EMType": 45,
-          "EntityIndex": 26,
-          "NewEntityType": 106
-        },
-        {
-          "EMType": 48,
-          "EntityIndex": 26,
-          "Intensity1": 5120,
-          "Intensity2": 4096
-        },
-        {
-          "EMType": 44,
-          "EntityIndex": 28,
-          "TargetLocation": {
-            "X": 31232,
-            "Y": -4096,
-            "Z": 66048,
-            "Room": 17,
-            "Angle": -32768
-          }
-        },
-        {
-          "EMType": 69,
-          "SwitchOrKeyRef": 28,
-          "Location": {
-            "X": 31232,
-            "Y": -4096,
-            "Z": 66048,
-            "Room": 17
-          }
-        },
-        {
-          "EMType": 45,
-          "EntityIndex": 73,
-          "NewEntityType": 103
-        },
-        {
-          "EMType": 45,
-          "EntityIndex": 74,
-          "NewEntityType": 106
-        },
-        {
-          "EMType": 48,
-          "EntityIndex": 74,
-          "Intensity1": 5120,
-          "Intensity2": 4096
-        },
-        {
-          "EMType": 44,
-          "EntityIndex": 73,
-          "TargetLocation": {
-            "X": 33280,
-            "Y": -4096,
-            "Z": 59904,
-            "Room": 43,
-            "Angle": -16384
-          }
-        },
-        {
-          "EMType": 69,
-          "SwitchOrKeyRef": 73,
-          "Location": {
-            "X": 33280,
-            "Y": -4096,
-            "Z": 60928,
-            "Room": 43
-          }
-        },
-        {
-          "EMType": 67,
-          "BaseLocation": {
-            "X": 33280,
-            "Y": -4096,
-            "Z": 60928,
-            "Room": 43
-          },
-          "NewLocation": {
-            "X": 33280,
-            "Y": -4096,
-            "Z": 59904,
-            "Room": 43
           }
         }
       ]


### PR DESCRIPTION
When Marco is present, we have to convert wheel doors into regular doors because Lara's MiscAnim model is replaced in this instance. Environment mods have been updated for Rig, Diving Area and Maria Doria for this scenario. A specific EM function has been made for this, to reduce the amount of JSON needed - it is basically a wrapper for several other functions.

Also makes an amendment to Winston-only mode to ensure "no restrictions" mode is implied, otherwise it was possible to have every enemy in Lair a dragon, which was unintended.