### PR TITLE
EM Serialization

### DIFF
--- a/TREnvironmentEditor/EMEditorMapping.cs
+++ b/TREnvironmentEditor/EMEditorMapping.cs
@@ -9,6 +9,12 @@ namespace TREnvironmentEditor
     public class EMEditorMapping
     {
         public static readonly EMConverter Converter = new EMConverter();
+        public static readonly JsonSerializerSettings Serializer = new JsonSerializerSettings
+        {
+            ContractResolver = new EMSerializationResolver(),
+            NullValueHandling = NullValueHandling.Ignore,
+            Formatting = Formatting.Indented
+        };
 
         public EMEditorSet All { get; set; }
         public List<EMConditionalSingleEditorSet> ConditionalAll { get; set; }
@@ -40,6 +46,16 @@ namespace TREnvironmentEditor
             }
 
             return null;
+        }
+
+        public void SerializeTo(string packPath)
+        {
+            File.WriteAllText(packPath, Serialize());
+        }
+
+        public string Serialize()
+        {
+            return JsonConvert.SerializeObject(this, Serializer);
         }
 
         public void AlternateTextures()

--- a/TREnvironmentEditor/Model/BaseEMCondition.cs
+++ b/TREnvironmentEditor/Model/BaseEMCondition.cs
@@ -1,10 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 using TRLevelReader.Model;
 
 namespace TREnvironmentEditor.Model
 {
     public abstract class BaseEMCondition
     {
+        [JsonProperty(Order = -2)]
+        public string Comments { get; set; }
+        [JsonProperty(Order = -2)]
         public EMConditionType ConditionType { get; set; }
         public bool Negate { get; set; }
         public List<BaseEMCondition> And { get; set; }

--- a/TREnvironmentEditor/Model/BaseEMFunction.cs
+++ b/TREnvironmentEditor/Model/BaseEMFunction.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Linq;
 using TRLevelReader.Model;
 
@@ -11,6 +12,9 @@ namespace TREnvironmentEditor.Model
         // Sector X/Z length
         public static readonly int SectorSize = 1024;
 
+        [JsonProperty(Order = -2)]
+        public string Comments { get; set; }
+        [JsonProperty(Order = -2)]
         public EMType EMType { get; set; }
 
         public abstract void ApplyToLevel(TR2Level level);

--- a/TREnvironmentEditor/Parsing/EMConverter.cs
+++ b/TREnvironmentEditor/Parsing/EMConverter.cs
@@ -11,8 +11,11 @@ namespace TREnvironmentEditor.Parsing
     {
         private static readonly JsonSerializerSettings _resolver = new JsonSerializerSettings
         {
-            ContractResolver = new EMResolver()
+            ContractResolver = new EMDeserializationResolver()
         };
+
+        private static readonly string _emTypeName = "EMType";
+        private static readonly string _conditionTypeName = "ConditionType";
 
         public override bool CanConvert(Type objectType)
         {
@@ -22,11 +25,11 @@ namespace TREnvironmentEditor.Parsing
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             JObject jo = JObject.Load(reader);
-            if (jo["EMType"] != null)
+            if (jo[_emTypeName] != null)
             {
                 return ReadEMType(jo);
             }
-            else if (jo["ConditionType"] != null)
+            else if (jo[_conditionTypeName] != null)
             {
                 return ReadConditionType(jo);
             }
@@ -36,7 +39,7 @@ namespace TREnvironmentEditor.Parsing
 
         private object ReadEMType(JObject jo)
         {
-            EMType type = (EMType)jo["EMType"].Value<int>();
+            EMType type = (EMType)jo[_emTypeName].Value<int>();
             switch (type)
             {
                 // Surface types
@@ -162,7 +165,7 @@ namespace TREnvironmentEditor.Parsing
 
         private object ReadConditionType(JObject jo)
         {
-            EMConditionType type = (EMConditionType)jo["ConditionType"].Value<int>();
+            EMConditionType type = (EMConditionType)jo[_conditionTypeName].Value<int>();
             switch (type)
             {
                 // Entities

--- a/TREnvironmentEditor/Parsing/EMDeserializationResolver.cs
+++ b/TREnvironmentEditor/Parsing/EMDeserializationResolver.cs
@@ -5,7 +5,7 @@ using TREnvironmentEditor.Model;
 
 namespace TREnvironmentEditor.Parsing
 {
-    public class EMResolver : DefaultContractResolver
+    public class EMDeserializationResolver : DefaultContractResolver
     {
         protected override JsonConverter ResolveContractConverter(Type objectType)
         {

--- a/TREnvironmentEditor/Parsing/EMSerializationResolver.cs
+++ b/TREnvironmentEditor/Parsing/EMSerializationResolver.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TREnvironmentEditor.Parsing
+{
+    // https://stackoverflow.com/questions/32571695/order-of-fields-when-serializing-the-derived-class-in-json-net
+    public class EMSerializationResolver : DefaultContractResolver
+    {
+        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+        {
+            return base.CreateProperties(type, memberSerialization)
+                ?.OrderBy(p => p.DeclaringType.BaseTypesAndSelf().Count()).ToList();
+        }
+    }
+
+    public static class TypeExtensions
+    {
+        public static IEnumerable<Type> BaseTypesAndSelf(this Type type)
+        {
+            while (type != null)
+            {
+                yield return type;
+                type = type.BaseType;
+            }
+        }
+    }
+}

--- a/TRFDControl/FDActionListItem.cs
+++ b/TRFDControl/FDActionListItem.cs
@@ -31,7 +31,7 @@ namespace TRFDControl
             }
             set
             {
-                Value = (ushort)(Value & ~(byte)TrigAction);
+                Value = (ushort)(Value & ~(Value & 0x7C00));
                 Value |= (ushort)((byte)value << 10);
             }
         }

--- a/TRFDControl/FDTrigSetup.cs
+++ b/TRFDControl/FDTrigSetup.cs
@@ -16,6 +16,11 @@ namespace TRFDControl
             {
                 return (byte)(Value & 0x00FF);
             }
+            set
+            {
+                Value = (ushort)(Value & ~(Value & 0x00FF));
+                Value |= value;
+            }
         }
 
         public bool OneShot
@@ -32,7 +37,8 @@ namespace TRFDControl
                 }
                 else
                 {
-                    Value ^= 0x0100;
+                    // Rather than Xor'ing, this allows successive calls with the same bool val
+                    Value = (ushort)(Value & ~0x0100);
                 }
             }
         }


### PR DESCRIPTION
## #333 EM Serialization

Reserialization of EM mapping is now supported. Although there will be added bloat for values not originally mentioned in the JSON, nulls will be ignored. The serializer will also take care to write inherited properties first so that these are set correctly on deserialization. The `Comments` and `EMType`/`ConditionType` fields will always be first for clarity if scanning through the JSON file.

In terms of testing, see https://github.com/lahm86/TREnvironmentEditorTests/blob/main/TREnvironmentEditorTests/RewriteTest.cs. This reads in current EM data, serializes it again and then applies each individual function from the original and "new" JSON on two separate level objects and verifies that the output is identical.

Some trigger issues came to light when the JSON has additional values that we hadn't specified before.
- Fixes the setting of `TrigAction` in `FDActionListItem` - it was previously removing the wrong value before setting the new one. The new JSON will have the value defined, previously we only specified `TrigAction` and `Parameter`. So this wasn't a problem before because the value was essentially 0, so the bug in line 34 of `FDActionListItem` wasn't kicking in.
- Fixes the setting of `OneShot` in `FDTrigSetup` as this was toggling rather than respecting the passed in value. This is similar to above, so because `OneShot` is always defined in the JSON, it was in effect toggling it after the value had been set already and so generally was becoming true in all cases.

Also:
- The `Timer` value in `FDTrigSetup` can now be set.
- Unit tests for FD updated for above.