### PR TITLE
#347 Key names in Bartoli's Hideout

### DIFF
--- a/TRRandomizerCore/Resources/TR2/Strings/G11N/gamestrings_FR.json
+++ b/TRRandomizerCore/Resources/TR2/Strings/G11N/gamestrings_FR.json
@@ -314,7 +314,7 @@
       ],
       "Keys": {
         "0": [
-          "Clé des livre",
+          "Clé des livres",
           "Une clé",
           "La clé",
           "Clé 1",
@@ -341,7 +341,8 @@
           "Clé facultative",
           "Clé qui ne sert pas",
           "Ça va péter !",
-          "Grimpe par le toit"
+          "Grimpe par le toit",
+          "Pastille Vichy"
         ]
       }
     },


### PR DESCRIPTION
Add an S to "livres" for the library key
Add an option "Pastille Vichy" to the detonator key