### PR TITLE
TR1 Enemy/Key Item Fixes

### DIFF
--- a/TREnvironmentEditor/Model/Types/Triggers/EMMoveTriggerFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Triggers/EMMoveTriggerFunction.cs
@@ -22,24 +22,38 @@ namespace TREnvironmentEditor.Model.Types
             control.ParseFromLevel(level);
 
             TRRoomSector baseSector = FDUtilities.GetRoomSector(BaseLocation.X, BaseLocation.Y, BaseLocation.Z, data.ConvertRoom(BaseLocation.Room), level, control);
-            TRRoomSector newSector;
+
             if (NewLocation != null)
             {
-                newSector = FDUtilities.GetRoomSector(NewLocation.X, NewLocation.Y, NewLocation.Z, data.ConvertRoom(NewLocation.Room), level, control);
+                NewLocation.Room = data.ConvertRoom(NewLocation.Room);
             }
             else if (EntityLocation.HasValue)
             {
                 TREntity entity = level.Entities[data.ConvertEntity(EntityLocation.Value)];
-                newSector = FDUtilities.GetRoomSector(entity.X, entity.Y, entity.Z, entity.Room, level, control);
+                NewLocation = new EMLocation
+                {
+                    X = entity.X,
+                    Y = entity.Y,
+                    Z = entity.Z,
+                    Room = data.ConvertRoom(entity.Room)
+                };
             }
             else
             {
-                throw new InvalidOperationException("No means to determine new sector for movign trigger.");
+                throw new InvalidOperationException("No means to determine new sector for moving trigger.");
             }
 
+            TRRoomSector newSector = FDUtilities.GetRoomSector(NewLocation.X, NewLocation.Y, NewLocation.Z, NewLocation.Room, level, control);
             if (MoveTriggers(baseSector, newSector, control))
             {
                 control.WriteToLevel(level);
+
+                // Make sure to copy the trigger into the flipped room if applicable
+                short altRoom = level.Rooms[NewLocation.Room].AlternateRoom;
+                if (altRoom != -1)
+                {
+                    CreateFlipmapTriggerFunction(altRoom).ApplyToLevel(level);
+                }
             }
         }
 
@@ -51,24 +65,38 @@ namespace TREnvironmentEditor.Model.Types
             control.ParseFromLevel(level);
 
             TRRoomSector baseSector = FDUtilities.GetRoomSector(BaseLocation.X, BaseLocation.Y, BaseLocation.Z, data.ConvertRoom(BaseLocation.Room), level, control);
-            TRRoomSector newSector;
+
             if (NewLocation != null)
             {
-                newSector = FDUtilities.GetRoomSector(NewLocation.X, NewLocation.Y, NewLocation.Z, data.ConvertRoom(NewLocation.Room), level, control);
+                NewLocation.Room = data.ConvertRoom(NewLocation.Room);
             }
             else if (EntityLocation.HasValue)
             {
                 TR2Entity entity = level.Entities[data.ConvertEntity(EntityLocation.Value)];
-                newSector = FDUtilities.GetRoomSector(entity.X, entity.Y, entity.Z, entity.Room, level, control);
+                NewLocation = new EMLocation
+                {
+                    X = entity.X,
+                    Y = entity.Y,
+                    Z = entity.Z,
+                    Room = data.ConvertRoom(entity.Room)
+                };
             }
             else
             {
-                throw new InvalidOperationException("No means to determine new sector for movign trigger.");
+                throw new InvalidOperationException("No means to determine new sector for moving trigger.");
             }
 
+            TRRoomSector newSector = FDUtilities.GetRoomSector(NewLocation.X, NewLocation.Y, NewLocation.Z, NewLocation.Room, level, control);
             if (MoveTriggers(baseSector, newSector, control))
             {
                 control.WriteToLevel(level);
+
+                // Make sure to copy the trigger into the flipped room if applicable
+                short altRoom = level.Rooms[NewLocation.Room].AlternateRoom;
+                if (altRoom != -1)
+                {
+                    CreateFlipmapTriggerFunction(altRoom).ApplyToLevel(level);
+                }
             }
         }
 
@@ -80,24 +108,38 @@ namespace TREnvironmentEditor.Model.Types
             control.ParseFromLevel(level);
 
             TRRoomSector baseSector = FDUtilities.GetRoomSector(BaseLocation.X, BaseLocation.Y, BaseLocation.Z, data.ConvertRoom(BaseLocation.Room), level, control);
-            TRRoomSector newSector;
+
             if (NewLocation != null)
             {
-                newSector = FDUtilities.GetRoomSector(NewLocation.X, NewLocation.Y, NewLocation.Z, data.ConvertRoom(NewLocation.Room), level, control);
+                NewLocation.Room = data.ConvertRoom(NewLocation.Room);
             }
             else if (EntityLocation.HasValue)
             {
                 TR2Entity entity = level.Entities[data.ConvertEntity(EntityLocation.Value)];
-                newSector = FDUtilities.GetRoomSector(entity.X, entity.Y, entity.Z, entity.Room, level, control);
+                NewLocation = new EMLocation
+                {
+                    X = entity.X,
+                    Y = entity.Y,
+                    Z = entity.Z,
+                    Room = data.ConvertRoom(entity.Room)
+                };
             }
             else
             {
-                throw new InvalidOperationException("No means to determine new sector for movign trigger.");
+                throw new InvalidOperationException("No means to determine new sector for moving trigger.");
             }
 
+            TRRoomSector newSector = FDUtilities.GetRoomSector(NewLocation.X, NewLocation.Y, NewLocation.Z, NewLocation.Room, level, control);
             if (MoveTriggers(baseSector, newSector, control))
             {
                 control.WriteToLevel(level);
+
+                // Make sure to copy the trigger into the flipped room if applicable
+                short altRoom = level.Rooms[NewLocation.Room].AlternateRoom;
+                if (altRoom != -1)
+                {
+                    CreateFlipmapTriggerFunction(altRoom).ApplyToLevel(level);
+                }
             }
         }
 
@@ -126,6 +168,26 @@ namespace TREnvironmentEditor.Model.Types
             }
 
             return false;
+        }
+
+        private EMDuplicateTriggerFunction CreateFlipmapTriggerFunction(short altRoom)
+        {
+            // We want the trigger that's in the new target location added to the same
+            // position in the flipped room.
+            return new EMDuplicateTriggerFunction
+            {
+                BaseLocation = NewLocation,
+                Locations = new List<EMLocation>
+                {
+                    new EMLocation
+                    {
+                        X = NewLocation.X,
+                        Y = NewLocation.Y,
+                        Z = NewLocation.Z,
+                        Room = altRoom
+                    }
+                }
+            };
         }
     }
 }

--- a/TRRandomizerCore/Randomizers/TR1/TR1EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1EnemyRandomizer.cs
@@ -595,7 +595,9 @@ namespace TRRandomizerCore.Randomizers
                 }
                 else if (currentEntityType == TREntities.AtlanteanEgg)
                 {
+                    // Hide what used to be eggs and reset the CodeBits otherwise this can interfere with trigger masks.
                     currentEntity.Invisible = true;
+                    currentEntity.CodeBits = 0;
                 }
 
                 if (newEntityType == TREntities.CentaurStatue)


### PR DESCRIPTION
* Ensures enemy CodeBits are reset if they were previously Atlantean eggs, otherwise this can cause the engine to interpret the bits as the trigger mask and so enemies don't spawn.
* Ensures that if a trigger is moved to a location whose room has a flipmap, the trigger will be duplicated into the flipped room as well.