### PR TITLE
Improve face drawing utility

### DIFF
--- a/TRImageControl/TRImage.Drawing.cs
+++ b/TRImageControl/TRImage.Drawing.cs
@@ -185,19 +185,17 @@ public partial class TRImage
         ReplaceFrom(img);
     }
 
+    public static Size MeasureString(string text, string fontName, float size)
+    {
+        var options = GetTextOptions(fontName, size);
+        var box = TextMeasurer.MeasureSize(text, options);
+        return new((int)box.Width, (int)box.Height);
+    }
+
     public void DrawString(string text, string fontName, float size, Color colour, int x, int y)
     {
-        if (!SystemFonts.TryGet(fontName, out FontFamily fontFamily))
-        {
-            throw new Exception($"Couldn't find font {fontName}");
-        }
-
-        Font font = fontFamily.CreateFont(size, FontStyle.Regular);
-        RichTextOptions options = new(font)
-        {
-            Origin = new(x, y),
-            Dpi = 72
-        };
+        var options = GetTextOptions(fontName, size);
+        options.Origin = new(x, y);
 
         using var img = ToImage();
         img.Mutate(ctx =>
@@ -206,5 +204,19 @@ public partial class TRImage
         });
 
         ReplaceFrom(img);
+    }
+
+    private static RichTextOptions GetTextOptions(string fontName, float size)
+    {
+        if (!SystemFonts.TryGet(fontName, out FontFamily fontFamily))
+        {
+            throw new Exception($"Couldn't find font {fontName}");
+        }
+
+        var font = fontFamily.CreateFont(size, FontStyle.Regular);
+        return new(font)
+        {
+            Dpi = 72,
+        };
     }
 }

--- a/TextureExport/Types/FaceMapper.cs
+++ b/TextureExport/Types/FaceMapper.cs
@@ -8,220 +8,82 @@ namespace TextureExport.Types;
 
 public static class FaceMapper
 {
-    public static void DrawFaces(TR1Level level, string lvl, int[] roomNumbers)
+    public static void DrawFaces(TR1Level level, string lvl, IEnumerable<int> roomNumbers, bool solidBackground)
     {
-        TR1TexturePacker packer = new(level, 255);
-
-        Dictionary<int, Dictionary<int, TRTextileRegion>> rectFaces = new();
-        Dictionary<int, Dictionary<int, TRTextileRegion>> triFaces = new();
-
-        Dictionary<int, Dictionary<int, int>> newRectFaces = new();
-        Dictionary<int, Dictionary<int, int>> newTriFaces = new();
-
-        foreach (int roomNumber in roomNumbers)
-        {
-            rectFaces[roomNumber] = new Dictionary<int, TRTextileRegion>();
-            triFaces[roomNumber] = new Dictionary<int, TRTextileRegion>();
-            newRectFaces[roomNumber] = new Dictionary<int, int>();
-            newTriFaces[roomNumber] = new Dictionary<int, int>();
-
-            for (int i = 0; i < level.Rooms[roomNumber].Mesh.Rectangles.Count; i++)
-            {
-                rectFaces[roomNumber][i] = GetFaceSegment(level.Rooms[roomNumber].Mesh.Rectangles[i].Texture, packer.Tiles);
-            }
-            for (int i = 0; i < level.Rooms[roomNumber].Mesh.Triangles.Count; i++)
-            {
-                triFaces[roomNumber][i] = GetFaceSegment(level.Rooms[roomNumber].Mesh.Triangles[i].Texture, packer.Tiles);
-            }
-
-            foreach (int rectIndex in rectFaces[roomNumber].Keys)
-            {
-                TRTextileRegion region = rectFaces[roomNumber][rectIndex];
-                if (region != null)
-                {
-                    TRTextileRegion newRegion = DrawNewFace(region, "Q" + rectIndex, true);
-                    packer.AddRectangle(newRegion);
-
-                    newRectFaces[roomNumber][rectIndex] = level.ObjectTextures.Count;
-                    level.ObjectTextures.Add(newRegion.Segments[0].Texture as TRObjectTexture);
-                }
-            }
-
-            foreach (int triIndex in triFaces[roomNumber].Keys)
-            {
-                TRTextileRegion region = triFaces[roomNumber][triIndex];
-                if (region != null)
-                {
-                    TRTextileRegion newRegion = DrawNewFace(region, "T" + triIndex, true);
-                    packer.AddRectangle(newRegion);
-
-                    newTriFaces[roomNumber][triIndex] = level.ObjectTextures.Count;
-                    level.ObjectTextures.Add(newRegion.Segments[0].Texture as TRObjectTexture);
-                }
-            }
-        }
-
-        packer.Pack(true);
-
-        foreach (int roomNumber in roomNumbers)
-        {
-            foreach (int rectIndex in newRectFaces[roomNumber].Keys)
-            {
-                level.Rooms[roomNumber].Mesh.Rectangles[rectIndex].Texture = (ushort)newRectFaces[roomNumber][rectIndex];
-            }
-            foreach (int triIndex in newTriFaces[roomNumber].Keys)
-            {
-                level.Rooms[roomNumber].Mesh.Triangles[triIndex].Texture = (ushort)newTriFaces[roomNumber][triIndex];
-            }
-        }
-
+        DrawFaces(level, roomNumbers.Select(r => level.Rooms[r].Mesh), solidBackground);
         Directory.CreateDirectory("TR1/Faces");
         new TR1LevelControl().Write(level, "TR1/Faces/" + lvl);
     }
 
-    public static void DrawFaces(TR2Level level, string lvl, int[] roomNumbers)
+    public static void DrawFaces(TR2Level level, string lvl, IEnumerable<int> roomNumbers, bool solidBackground)
     {
-        TR2TexturePacker packer = new(level, 255);
-
-        Dictionary<int, Dictionary<int, TRTextileRegion>> rectFaces = new();
-        Dictionary<int, Dictionary<int, TRTextileRegion>> triFaces = new();
-
-        Dictionary<int, Dictionary<int, int>> newRectFaces = new();
-        Dictionary<int, Dictionary<int, int>> newTriFaces = new();
-
-        foreach (int roomNumber in roomNumbers)
-        {
-            rectFaces[roomNumber] = new Dictionary<int, TRTextileRegion>();
-            triFaces[roomNumber] = new Dictionary<int, TRTextileRegion>();
-            newRectFaces[roomNumber] = new Dictionary<int, int>();
-            newTriFaces[roomNumber] = new Dictionary<int, int>();
-
-            for (int i = 0; i < level.Rooms[roomNumber].Mesh.Rectangles.Count; i++)
-            {
-                rectFaces[roomNumber][i] = GetFaceSegment(level.Rooms[roomNumber].Mesh.Rectangles[i].Texture, packer.Tiles);
-            }
-            for (int i = 0; i < level.Rooms[roomNumber].Mesh.Triangles.Count; i++)
-            {
-                triFaces[roomNumber][i] = GetFaceSegment(level.Rooms[roomNumber].Mesh.Triangles[i].Texture, packer.Tiles);
-            }
-
-            foreach (int rectIndex in rectFaces[roomNumber].Keys)
-            {
-                TRTextileRegion region = rectFaces[roomNumber][rectIndex];
-                if (region != null)
-                {
-                    TRTextileRegion newRegion = DrawNewFace(region, "Q" + rectIndex);
-                    packer.AddRectangle(newRegion);
-
-                    newRectFaces[roomNumber][rectIndex] = level.ObjectTextures.Count;
-                    level.ObjectTextures.Add(newRegion.Segments[0].Texture as TRObjectTexture);
-                }
-            }
-
-            foreach (int triIndex in triFaces[roomNumber].Keys)
-            {
-                TRTextileRegion region = triFaces[roomNumber][triIndex];
-                if (region != null)
-                {
-                    TRTextileRegion newRegion = DrawNewFace(region, "T" + triIndex);
-                    packer.AddRectangle(newRegion);
-
-                    newTriFaces[roomNumber][triIndex] = level.ObjectTextures.Count;
-                    level.ObjectTextures.Add(newRegion.Segments[0].Texture as TRObjectTexture);
-                }
-            }
-        }
-
-        packer.Pack(true);
-
-        foreach (int roomNumber in roomNumbers)
-        {
-            foreach (int rectIndex in newRectFaces[roomNumber].Keys)
-            {
-                level.Rooms[roomNumber].Mesh.Rectangles[rectIndex].Texture = (ushort)newRectFaces[roomNumber][rectIndex];
-            }
-            foreach (int triIndex in newTriFaces[roomNumber].Keys)
-            {
-                level.Rooms[roomNumber].Mesh.Triangles[triIndex].Texture = (ushort)newTriFaces[roomNumber][triIndex];
-            }
-        }
-
+        DrawFaces(level, roomNumbers.Select(r => level.Rooms[r].Mesh), solidBackground);
         Directory.CreateDirectory("TR2/Faces");
         new TR2LevelControl().Write(level, "TR2/Faces/" + lvl);
     }
 
-    public static void DrawFaces(TR3Level level, string lvl, int[] roomNumbers)
+    public static void DrawFaces(TR3Level level, string lvl, IEnumerable<int> roomNumbers, bool solidBackground)
     {
-        TR3TexturePacker packer = new(level, 255);
-
-        Dictionary<int, Dictionary<int, TRTextileRegion>> rectFaces = new();
-        Dictionary<int, Dictionary<int, TRTextileRegion>> triFaces = new();
-
-        Dictionary<int, Dictionary<int, int>> newRectFaces = new();
-        Dictionary<int, Dictionary<int, int>> newTriFaces = new();
-
-        foreach (int roomNumber in roomNumbers)
-        {
-            rectFaces[roomNumber] = new Dictionary<int, TRTextileRegion>();
-            triFaces[roomNumber] = new Dictionary<int, TRTextileRegion>();
-            newRectFaces[roomNumber] = new Dictionary<int, int>();
-            newTriFaces[roomNumber] = new Dictionary<int, int>();
-
-            for (int i = 0; i < level.Rooms[roomNumber].Mesh.Rectangles.Count; i++)
-            {
-                rectFaces[roomNumber][i] = GetFaceSegment(level.Rooms[roomNumber].Mesh.Rectangles[i].Texture, packer.Tiles);
-            }
-            for (int i = 0; i < level.Rooms[roomNumber].Mesh.Triangles.Count; i++)
-            {
-                triFaces[roomNumber][i] = GetFaceSegment(level.Rooms[roomNumber].Mesh.Triangles[i].Texture, packer.Tiles);
-            }
-
-            foreach (int rectIndex in rectFaces[roomNumber].Keys)
-            {
-                TRTextileRegion region = rectFaces[roomNumber][rectIndex];
-                if (region != null)
-                {
-                    TRTextileRegion newRegion = DrawNewFace(region, "Q" + rectIndex);
-                    packer.AddRectangle(newRegion);
-
-                    newRectFaces[roomNumber][rectIndex] = level.ObjectTextures.Count;
-                    level.ObjectTextures.Add(newRegion.Segments[0].Texture as TRObjectTexture);
-                }
-            }
-
-            foreach (int triIndex in triFaces[roomNumber].Keys)
-            {
-                TRTextileRegion region = triFaces[roomNumber][triIndex];
-                if (region != null)
-                {
-                    TRTextileRegion newRegion = DrawNewFace(region, "T" + triIndex);
-                    packer.AddRectangle(newRegion);
-
-                    newTriFaces[roomNumber][triIndex] = level.ObjectTextures.Count;
-                    level.ObjectTextures.Add(newRegion.Segments[0].Texture as TRObjectTexture);
-                }
-            }
-        }
-
-        packer.Pack(true);
-
-        foreach (int roomNumber in roomNumbers)
-        {
-            foreach (int rectIndex in newRectFaces[roomNumber].Keys)
-            {
-                level.Rooms[roomNumber].Mesh.Rectangles[rectIndex].Texture = (ushort)newRectFaces[roomNumber][rectIndex];
-            }
-            foreach (int triIndex in newTriFaces[roomNumber].Keys)
-            {
-                level.Rooms[roomNumber].Mesh.Triangles[triIndex].Texture = (ushort)newTriFaces[roomNumber][triIndex];
-            }
-        }
-
+        DrawFaces(level, roomNumbers.Select(r => level.Rooms[r].Mesh), solidBackground);
         Directory.CreateDirectory("TR3/Faces");
         new TR3LevelControl().Write(level, "TR3/Faces/" + lvl);
     }
 
-    public static void DrawBoxes(TR2Level level, string lvl, int[] roomNumbers)
+    public static void DrawFaces<T, V>(TRLevelBase level, IEnumerable<TRRoomMesh<T, V>> meshes, bool solidBackground)
+        where T : Enum
+        where V : TRRoomVertex
+    {
+        var packer = GetPacker(level);
+
+        void RedrawFace(TRFace face, int index)
+        {
+            var region = GetFaceSegment(face.Texture, packer.Tiles);
+            if (region == null)
+            {
+                return;
+            }
+
+            bool isTriangle = face.Type == TRFaceType.Triangle;
+            var newRegion = DrawNewFace(region, $"{(isTriangle ? "T" : "Q")}{index}", isTriangle, solidBackground);
+            packer.AddRectangle(newRegion);
+
+            face.Texture = (ushort)level.ObjectTextures.Count;
+            level.ObjectTextures.Add(newRegion.Segments[0].Texture as TRObjectTexture);
+        }
+
+        foreach (var mesh in meshes)
+        {
+            for (int i = 0; i < mesh.Rectangles.Count; i++)
+            {
+                RedrawFace(mesh.Rectangles[i], i);
+            }
+            for (int i = 0; i < mesh.Triangles.Count; i++)
+            {
+                RedrawFace(mesh.Triangles[i], i);
+            }
+        }
+
+        packer.Pack(true);
+    }
+
+    private static TRTexturePacker GetPacker(TRLevelBase level)
+    {
+        if (level is TR1Level level1)
+        {
+            return new TR1TexturePacker(level1, 1024);
+        }
+        else if (level is TR2Level level2)
+        {
+            return new TR2TexturePacker(level2, 1024);
+        }
+        else if (level is TR3Level level3)
+        {
+            return new TR3TexturePacker(level3, 1024);
+        }
+        throw new Exception();
+    }
+
+    public static void DrawBoxes(TR2Level level, string lvl, IEnumerable<int> roomNumbers)
     {
         TR2TexturePacker packer = new(level, 10000);
 
@@ -245,7 +107,7 @@ public static class FaceMapper
             foreach (int rectIndex in rectFaces[roomNumber].Keys)
             {
                 TRTextileRegion region = rectFaces[roomNumber][rectIndex];
-                TRTextileRegion newRegion = DrawNewFace(region, GetBoxDescription(level, roomNumber, rectIndex));
+                TRTextileRegion newRegion = DrawNewFace(region, GetBoxDescription(level, roomNumber, rectIndex), false);
                 packer.AddRectangle(newRegion);
 
                 newRectFaces[roomNumber][rectIndex] = level.ObjectTextures.Count;
@@ -267,15 +129,42 @@ public static class FaceMapper
         new TR2LevelControl().Write(level, "TR2/Boxes/" + lvl);
     }
 
-    private static TRTextileRegion DrawNewFace(TRTextileRegion segment, string text, bool fillBackground = false)
+    private static TRTextileRegion DrawNewFace(TRTextileRegion segment, string text, bool isTriangle, bool fillBackground = false)
     {
         TRImage image = segment.Image.Clone();
         if (fillBackground)
         {
             image.Fill(Color.Black);
         }
+        image.DrawRectangle(Color.Red, 0, 0, image.Width - 1, image.Height - 1);
 
-        image.DrawString(text, "Arial", 10, Color.Red, 4, 4);
+        const string fontName = "Arial";
+        const int fontSize = 12;
+
+        var size = TRImage.MeasureString(text, fontName, fontSize);
+        var width = image.Width - size.Width;
+        var height = image.Height - size.Height;
+        if (isTriangle)
+        {
+            // Can't guarantee orientation on face is good, so improve readability chance
+            const int padding = 8;
+            var corners = new(int x, int y)[]
+            {
+                (padding, padding),
+                (width - padding, padding),
+                (width - padding, height - padding),
+                (padding, height - padding),
+            };
+
+            foreach (var (x, y) in corners)
+            {
+                image.DrawString(text, fontName, fontSize, Color.Red, x, y);
+            }
+        }
+        else
+        {
+            image.DrawString(text, fontName, fontSize, Color.Red, width / 2, height / 2);
+        }
 
         return new TRTextileRegion(CreateTexture(segment.Bounds), image);
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Updates the utility that draws room face indices on textures and writes back to the level (for fixing OG texture issues). TR1 used to always draw a solid background whereas TR2/3 drew on top of the actual texture (I can't remember why). The option to draw solid or on top can be passed as an arg now for 1-3, and defaults to off.
Also improves the appearance by adding a border, centering the text on quads and drawing it in each corner for triangles for better readability chance.

<details><summary>E.g.</summary>

<img width="1192" height="638" alt="image" src="https://github.com/user-attachments/assets/d57f983c-66e1-417c-80d2-1ef3530ca3a6" />
</details>
